### PR TITLE
Add encrypted database server implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,82 @@
+# Encrypted Database System
+
+This repository contains a minimal encrypted database system for securely storing files (such as images) and associated metadata. The system exposes a simple REST API, implemented with Flask, that encrypts data using the AES-based [`cryptography`](https://cryptography.io/) `Fernet` algorithm before persisting the records to a SQLite database.
+
+## Overview
+
+* **Encryption**: AES-128 in CBC mode with PKCS7 padding via Fernet. The secret key must be provided as a base64-encoded string via the `ENCRYPTION_KEY` environment variable.
+* **Storage**: SQLite database (`server/secure_store.db`) that stores encrypted blobs along with metadata (filename, content type, and arbitrary text metadata).
+* **API**:
+  * `POST /records` – Upload a new file along with optional metadata. Returns the numeric record id.
+  * `GET /records` – List metadata for all stored files.
+  * `GET /records/<id>` – Download the decrypted file.
+  * `GET /records/<id>/metadata` – Retrieve metadata for a specific record.
+
+## Getting Started
+
+1. Create and activate a virtual environment (optional but recommended).
+2. Install dependencies:
+
+   ```bash
+   pip install -r server/requirements.txt
+   ```
+
+3. Generate an encryption key (only once). You can use the helper script:
+
+   ```bash
+   python -m server.encryption --generate
+   ```
+
+   Save the printed key somewhere safe. Set it as an environment variable before running the server:
+
+   ```bash
+   export ENCRYPTION_KEY="<your generated key>"
+   ```
+
+4. Start the server:
+
+   ```bash
+   python -m server.app
+   ```
+
+   The API listens on `http://0.0.0.0:8000`. Ensure that the server machine is reachable via Ethernet or the desired network interface.
+
+## Using the API
+
+Below are example `curl` commands for interacting with the API.
+
+### Upload a file
+
+```bash
+curl -X POST \
+     -F "file=@/path/to/image.png" \
+     -F "filename=custom-name.png" \
+     -F "metadata={\"description\": \"Sample image\"}" \
+     -F "content_type=image/png" \
+     http://localhost:8000/records
+```
+
+### List all records
+
+```bash
+curl http://localhost:8000/records
+```
+
+### Download a specific record
+
+```bash
+curl -o output.png http://localhost:8000/records/<id>
+```
+
+### Retrieve metadata only
+
+```bash
+curl http://localhost:8000/records/<id>/metadata
+```
+
+## Security Considerations
+
+* Protect the `ENCRYPTION_KEY` value. Anyone with this key can decrypt stored data.
+* Enable HTTPS (e.g., via a reverse proxy such as Nginx with TLS certificates) to protect data in transit.
+* Consider integrating authentication/authorization for production deployments.
+* Regularly back up `server/secure_store.db` and ensure backup security.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,15 @@ This repository contains a minimal encrypted database system for securely storin
    export ENCRYPTION_KEY="<your generated key>"
    ```
 
-4. Start the server:
+4. (Optional) Override the database location by setting ``SECURE_STORE_DB`` to
+   an absolute or relative path. This is useful when operating the system
+   offline and syncing the encrypted store via removable media.
+
+   ```bash
+   export SECURE_STORE_DB="/path/to/secure_store.db"
+   ```
+
+5. Start the server:
 
    ```bash
    python -m server.app
@@ -73,6 +81,31 @@ curl -o output.png http://localhost:8000/records/<id>
 ```bash
 curl http://localhost:8000/records/<id>/metadata
 ```
+
+## Offline Usage
+
+The system can be used without the REST API by invoking the offline command
+line utilities:
+
+```bash
+# Initialize (or migrate) the database file
+python -m server.cli init
+
+# Store a new file with optional metadata
+python -m server.cli add path/to/image.png --metadata '{"description": "Offline import"}'
+
+# List available records
+python -m server.cli list
+
+# Retrieve a record to disk
+python -m server.cli get 1 --output restored.png
+
+# Inspect metadata for a record
+python -m server.cli metadata 1
+```
+
+All commands respect the same ``ENCRYPTION_KEY`` and ``SECURE_STORE_DB``
+environment variables as the web server, enabling a fully offline workflow.
 
 ## Security Considerations
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,0 +1,5 @@
+"""Encrypted database API package."""
+
+from .app import app
+
+__all__ = ["app"]

--- a/server/app.py
+++ b/server/app.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import io
+from http import HTTPStatus
+from typing import Any
+
+from flask import Flask, jsonify, request, send_file
+
+from . import database
+from . import encryption
+
+app = Flask(__name__)
+
+
+def _serialize_row(row: Any) -> dict[str, Any]:
+    return {
+        "id": row["id"],
+        "filename": row["filename"],
+        "content_type": row["content_type"],
+        "metadata": row["metadata"],
+    }
+
+
+@app.before_first_request
+def setup_database() -> None:
+    database.initialize_database()
+
+
+@app.post("/records")
+def create_record() -> tuple[Any, int]:
+    upload = request.files.get("file")
+    if upload is None:
+        return jsonify({"error": "Missing file upload"}), HTTPStatus.BAD_REQUEST
+
+    filename = request.form.get("filename") or upload.filename or "untitled"
+    metadata = request.form.get("metadata")
+    content_type = request.form.get("content_type") or upload.mimetype or "application/octet-stream"
+
+    raw_data = upload.read()
+    if not raw_data:
+        return jsonify({"error": "Uploaded file is empty"}), HTTPStatus.BAD_REQUEST
+
+    encrypted_data = encryption.encrypt(raw_data)
+
+    record_id = database.insert_record(filename, content_type, metadata, encrypted_data)
+
+    return jsonify({"id": record_id}), HTTPStatus.CREATED
+
+
+@app.get("/records")
+def list_records() -> Any:
+    rows = database.fetch_all_metadata()
+    return jsonify([_serialize_row(row) for row in rows])
+
+
+@app.get("/records/<int:record_id>")
+def download_record(record_id: int):
+    row = database.fetch_record_blob(record_id)
+    if row is None:
+        return jsonify({"error": "Record not found"}), HTTPStatus.NOT_FOUND
+
+    decrypted = encryption.decrypt(row["encrypted_data"])
+
+    return send_file(
+        io.BytesIO(decrypted),
+        mimetype=row["content_type"] or "application/octet-stream",
+        as_attachment=True,
+        download_name=row["filename"],
+    )
+
+
+@app.get("/records/<int:record_id>/metadata")
+def fetch_metadata(record_id: int):
+    row = database.fetch_metadata(record_id)
+    if row is None:
+        return jsonify({"error": "Record not found"}), HTTPStatus.NOT_FOUND
+    return jsonify(_serialize_row(row))
+
+
+if __name__ == "__main__":
+    # Ensure the database exists when running the server directly
+    database.initialize_database()
+    app.run(host="0.0.0.0", port=8000)

--- a/server/cli.py
+++ b/server/cli.py
@@ -1,0 +1,147 @@
+"""Command line utilities for interacting with the encrypted store offline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from . import database, encryption
+
+
+def _load_metadata(metadata: str | None, metadata_file: str | None) -> str | None:
+    if metadata and metadata_file:
+        raise ValueError("Provide metadata via either --metadata or --metadata-file, not both.")
+
+    if metadata_file:
+        data = Path(metadata_file).read_text(encoding="utf-8")
+        # Validate JSON to ensure consistent formatting when stored.
+        json.loads(data)
+        return data
+
+    if metadata:
+        # Ensure provided metadata is valid JSON.
+        json.loads(metadata)
+        return metadata
+
+    return None
+
+
+def _cmd_init_database(_: argparse.Namespace) -> None:
+    database.initialize_database()
+    db_path = database.get_database_path()
+    print(f"Database initialized at {db_path}")
+
+
+def _cmd_add(args: argparse.Namespace) -> None:
+    file_path = Path(args.file)
+    if not file_path.is_file():
+        raise SystemExit(f"File not found: {file_path}")
+
+    payload = file_path.read_bytes()
+    if not payload:
+        raise SystemExit("Cannot store empty files.")
+
+    filename = args.filename or file_path.name
+    try:
+        metadata = _load_metadata(args.metadata, args.metadata_file)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    encrypted = encryption.encrypt(payload)
+    record_id = database.insert_record(
+        filename=filename,
+        content_type=args.content_type,
+        metadata=metadata,
+        encrypted_data=encrypted,
+    )
+    print(f"Stored record {record_id} ({filename})")
+
+
+def _cmd_list(_: argparse.Namespace) -> None:
+    rows = database.fetch_all_metadata()
+    for row in rows:
+        metadata_preview: str | None = row["metadata"]
+        if metadata_preview and len(metadata_preview) > 60:
+            metadata_preview = metadata_preview[:57] + "..."
+        print(
+            f"id={row['id']} filename={row['filename']} content_type={row['content_type']} "
+            f"metadata={metadata_preview}"
+        )
+
+
+def _cmd_get(args: argparse.Namespace) -> None:
+    row = database.fetch_record_blob(args.record_id)
+    if row is None:
+        raise SystemExit(f"Record {args.record_id} not found")
+
+    decrypted = encryption.decrypt(row["encrypted_data"])
+    output_path = Path(args.output)
+    output_path.write_bytes(decrypted)
+    print(f"Record {args.record_id} written to {output_path}")
+
+
+def _cmd_metadata(args: argparse.Namespace) -> None:
+    row = database.fetch_metadata(args.record_id)
+    if row is None:
+        raise SystemExit(f"Record {args.record_id} not found")
+
+    metadata = row["metadata"]
+    if metadata:
+        parsed: Any = json.loads(metadata)
+        json.dump(parsed, sys.stdout, indent=2)
+        print()
+    else:
+        print("{}")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Offline encrypted store utilities")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init", help="Create the database file if needed")
+    init_parser.set_defaults(func=_cmd_init_database)
+
+    add_parser = subparsers.add_parser("add", help="Encrypt and store a file")
+    add_parser.add_argument("file", help="Path to the file to store")
+    add_parser.add_argument(
+        "--filename",
+        help="Optional filename to record (defaults to the uploaded filename)",
+    )
+    add_parser.add_argument(
+        "--content-type",
+        default="application/octet-stream",
+        help="MIME type for the stored file",
+    )
+    add_parser.add_argument("--metadata", help="JSON string with metadata")
+    add_parser.add_argument(
+        "--metadata-file",
+        help="Path to a JSON file containing metadata",
+    )
+    add_parser.set_defaults(func=_cmd_add)
+
+    list_parser = subparsers.add_parser("list", help="Display stored record metadata")
+    list_parser.set_defaults(func=_cmd_list)
+
+    get_parser = subparsers.add_parser("get", help="Decrypt a stored record to disk")
+    get_parser.add_argument("record_id", type=int, help="Record identifier to retrieve")
+    get_parser.add_argument("--output", required=True, help="Destination file path")
+    get_parser.set_defaults(func=_cmd_get)
+
+    metadata_parser = subparsers.add_parser("metadata", help="Show metadata for a record")
+    metadata_parser.add_argument("record_id", type=int, help="Record identifier")
+    metadata_parser.set_defaults(func=_cmd_metadata)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    database.initialize_database()
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/server/database.py
+++ b/server/database.py
@@ -1,15 +1,47 @@
 from __future__ import annotations
 
+import os
 import sqlite3
-from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator
 
-_DB_FILE = Path(__file__).resolve().parent / "secure_store.db"
+_DB_FILE_ENV_VAR = "SECURE_STORE_DB"
+
+
+def _default_db_path() -> Path:
+    """Return the default location of the SQLite file."""
+
+    return Path(__file__).resolve().parent / "secure_store.db"
+
+
+def _db_file_path() -> Path:
+    """Determine the SQLite file path.
+
+    The location can be overridden by setting the ``SECURE_STORE_DB``
+    environment variable to an absolute or relative path. Relative paths are
+    resolved against the current working directory to make offline usage with
+    custom storage locations straightforward.
+    """
+
+    env_path = os.getenv(_DB_FILE_ENV_VAR)
+    if not env_path:
+        return _default_db_path()
+
+    candidate = Path(env_path).expanduser()
+    if not candidate.is_absolute():
+        candidate = (Path.cwd() / candidate).resolve()
+    else:
+        candidate = candidate.resolve()
+    return candidate
+
+
+def get_database_path() -> Path:
+    """Public helper that exposes the resolved database path."""
+
+    return _db_file_path()
 
 
 def get_connection() -> sqlite3.Connection:
-    connection = sqlite3.connect(_DB_FILE)
+    connection = sqlite3.connect(_db_file_path())
     connection.row_factory = sqlite3.Row
     return connection
 

--- a/server/database.py
+++ b/server/database.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+_DB_FILE = Path(__file__).resolve().parent / "secure_store.db"
+
+
+def get_connection() -> sqlite3.Connection:
+    connection = sqlite3.connect(_DB_FILE)
+    connection.row_factory = sqlite3.Row
+    return connection
+
+
+def initialize_database() -> None:
+    with get_connection() as connection:
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS records (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                filename TEXT NOT NULL,
+                content_type TEXT,
+                metadata TEXT,
+                encrypted_data BLOB NOT NULL
+            )
+            """
+        )
+
+
+def insert_record(
+    filename: str, content_type: str, metadata: str | None, encrypted_data: bytes
+) -> int:
+    with get_connection() as connection:
+        cursor = connection.execute(
+            """
+            INSERT INTO records (filename, content_type, metadata, encrypted_data)
+            VALUES (?, ?, ?, ?)
+            """,
+            (filename, content_type, metadata, encrypted_data),
+        )
+        connection.commit()
+        return int(cursor.lastrowid)
+
+
+def fetch_metadata(record_id: int) -> sqlite3.Row | None:
+    with get_connection() as connection:
+        cursor = connection.execute(
+            "SELECT id, filename, content_type, metadata FROM records WHERE id = ?",
+            (record_id,),
+        )
+        return cursor.fetchone()
+
+
+def fetch_all_metadata() -> list[sqlite3.Row]:
+    with get_connection() as connection:
+        cursor = connection.execute(
+            "SELECT id, filename, content_type, metadata FROM records ORDER BY id"
+        )
+        return cursor.fetchall()
+
+
+def fetch_record_blob(record_id: int) -> sqlite3.Row | None:
+    with get_connection() as connection:
+        cursor = connection.execute(
+            """
+            SELECT id, filename, content_type, encrypted_data
+            FROM records
+            WHERE id = ?
+            """,
+            (record_id,),
+        )
+        return cursor.fetchone()

--- a/server/encryption.py
+++ b/server/encryption.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import base64
+import os
+from typing import Optional
+
+from cryptography.fernet import Fernet
+
+
+_KEY_ENV_VAR = "ENCRYPTION_KEY"
+
+
+def load_key(key: Optional[str] = None) -> bytes:
+    """Return the encryption key as bytes.
+
+    If ``key`` is provided it is used directly. Otherwise the function attempts to
+    read the key from the ``ENCRYPTION_KEY`` environment variable.
+    """
+    key_to_use = key or os.getenv(_KEY_ENV_VAR)
+    if not key_to_use:
+        raise RuntimeError(
+            "Encryption key is not set. Provide a key explicitly or set the "
+            f"{_KEY_ENV_VAR} environment variable."
+        )
+    if isinstance(key_to_use, bytes):
+        return key_to_use
+    return key_to_use.encode("utf-8")
+
+
+def encrypt(data: bytes, key: Optional[str] = None) -> bytes:
+    """Encrypt ``data`` using the provided key.
+
+    The key must be a URL safe base64-encoded 32-byte key as required by
+    :class:`cryptography.fernet.Fernet`.
+    """
+    fernet = Fernet(load_key(key))
+    return fernet.encrypt(data)
+
+
+def decrypt(token: bytes, key: Optional[str] = None) -> bytes:
+    """Decrypt ``token`` and return the original bytes."""
+    fernet = Fernet(load_key(key))
+    return fernet.decrypt(token)
+
+
+def generate_key() -> str:
+    """Generate a new key and return it as a string.
+
+    ``Fernet`` keys are already URL-safe base64-encoded 32-byte values.
+    """
+    return Fernet.generate_key().decode("utf-8")
+
+
+def write_key_to_file(path: str) -> str:
+    """Generate a key and write it to ``path``.
+
+    The function returns the generated key to allow printing it for the user.
+    """
+    key = generate_key()
+    with open(path, "w", encoding="utf-8") as key_file:
+        key_file.write(key)
+    return key
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate or display Fernet keys.")
+    parser.add_argument(
+        "--generate", action="store_true", help="Generate a new key and print it"
+    )
+    parser.add_argument(
+        "--write", metavar="PATH", help="Generate a new key and write it to PATH"
+    )
+
+    args = parser.parse_args()
+
+    if args.write:
+        new_key = write_key_to_file(args.write)
+        print(f"Key written to {args.write}. Value: {new_key}")
+    elif args.generate:
+        print(generate_key())
+    else:
+        env_key = os.getenv(_KEY_ENV_VAR)
+        if env_key:
+            print(f"Current key from {_KEY_ENV_VAR}: {env_key}")
+        else:
+            print(
+                "No key set. Use --generate to create one or set the "
+                f"{_KEY_ENV_VAR} environment variable."
+            )

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,0 +1,2 @@
+Flask>=2.3
+cryptography>=41.0


### PR DESCRIPTION
## Summary
- add a Flask-based API for an encrypted SQLite-backed file store
- include Fernet-based encryption utilities and database helpers
- document setup, key management, and API usage in the README

## Testing
- python -m compileall server

------
https://chatgpt.com/codex/tasks/task_e_68e00f08f0f88331a1979086ff6fb99d