### PR TITLE
Add bank templates, offline account UI and encrypted storage (AES-GCM with DPAPI key)

### DIFF
--- a/BankAssets/BankAssets.vbproj
+++ b/BankAssets/BankAssets.vbproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <RootNamespace>BankAssets</RootNamespace>
+    <UseWindowsForms>true</UseWindowsForms>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.4" />
+  </ItemGroup>
+</Project>

--- a/BankAssets/Data/Database.vb
+++ b/BankAssets/Data/Database.vb
@@ -1,0 +1,67 @@
+Imports System.IO
+Imports Microsoft.Data.Sqlite
+
+Namespace BankAssets.Data
+    Public Class Database
+        Private ReadOnly _settingsService As Services.SettingsService
+        Private ReadOnly _encryptionService As Services.EncryptionService
+
+        Public Sub New(settingsService As Services.SettingsService)
+            _settingsService = settingsService
+            _encryptionService = New Services.EncryptionService(settingsService.GetEncryptionKey())
+        End Sub
+
+        Public ReadOnly Property EncryptionService As Services.EncryptionService
+            Get
+                Return _encryptionService
+            End Get
+        End Property
+
+        Public Function CreateConnection() As SqliteConnection
+            Dim dbPath = _settingsService.LoadDatabasePath()
+            Dim connectionString = New SqliteConnectionStringBuilder With {
+                .DataSource = dbPath
+            }
+            Return New SqliteConnection(connectionString.ToString())
+        End Function
+
+        Public Sub Initialize()
+            Dim dbPath = _settingsService.LoadDatabasePath()
+            If String.IsNullOrWhiteSpace(dbPath) Then
+                Throw New InvalidOperationException("Database path is not configured.")
+            End If
+
+            Directory.CreateDirectory(Path.GetDirectoryName(dbPath))
+            Using connection = CreateConnection()
+                connection.Open()
+                Dim command = connection.CreateCommand()
+                command.CommandText = """
+                CREATE TABLE IF NOT EXISTS banks (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    api_type TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS accounts (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    bank_id INTEGER NOT NULL,
+                    name TEXT NOT NULL,
+                    iban TEXT NOT NULL,
+                    current_balance TEXT NOT NULL,
+                    last_synced_at TEXT NULL,
+                    FOREIGN KEY(bank_id) REFERENCES banks(id)
+                );
+                CREATE TABLE IF NOT EXISTS transactions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    account_id INTEGER NOT NULL,
+                    amount TEXT NOT NULL,
+                    purpose TEXT NOT NULL,
+                    booking_date TEXT NOT NULL,
+                    counterparty TEXT NOT NULL,
+                    FOREIGN KEY(account_id) REFERENCES accounts(id)
+                );
+                """
+                command.ExecuteNonQuery()
+            End Using
+        End Sub
+    End Class
+End Namespace

--- a/BankAssets/Forms/AccountDetailForm.vb
+++ b/BankAssets/Forms/AccountDetailForm.vb
@@ -1,0 +1,146 @@
+Imports System.Globalization
+Imports System.Windows.Forms
+Imports System.Windows.Forms.DataVisualization.Charting
+
+Namespace BankAssets.Forms
+    Public Class AccountDetailForm
+        Inherits Form
+
+        Private ReadOnly _database As Data.Database
+        Private ReadOnly _account As Models.Account
+        Private ReadOnly _transactionRepository As Repositories.TransactionRepository
+        Private ReadOnly _accountRepository As Repositories.AccountRepository
+        Private ReadOnly _transactionList As ListView
+        Private ReadOnly _chart As Chart
+        Private ReadOnly _fromPicker As DateTimePicker
+        Private ReadOnly _toPicker As DateTimePicker
+
+        Public Sub New(database As Data.Database, account As Models.Account)
+            _database = database
+            _account = account
+            _transactionRepository = New Repositories.TransactionRepository(database)
+            _accountRepository = New Repositories.AccountRepository(database)
+
+            Text = $"Kontoübersicht - {_account.Name}"
+            Width = 1000
+            Height = 700
+            StartPosition = FormStartPosition.CenterScreen
+
+            Dim filterLabel = New Label With {
+                .Text = "Filter Zeitraum:",
+                .Left = 20,
+                .Top = 15,
+                .AutoSize = True
+            }
+
+            _fromPicker = New DateTimePicker With {
+                .Left = 130,
+                .Top = 10,
+                .Width = 120,
+                .Format = DateTimePickerFormat.Short
+            }
+            _toPicker = New DateTimePicker With {
+                .Left = 270,
+                .Top = 10,
+                .Width = 120,
+                .Format = DateTimePickerFormat.Short
+            }
+            Dim applyButton = New Button With {
+                .Text = "Anwenden",
+                .Left = 410,
+                .Top = 8,
+                .Width = 90
+            }
+            AddHandler applyButton.Click, AddressOf OnApplyFilter
+
+            Dim addTransactionButton = New Button With {
+                .Text = "Transaktion hinzufügen",
+                .Left = 520,
+                .Top = 8,
+                .Width = 170
+            }
+            AddHandler addTransactionButton.Click, AddressOf OnAddTransaction
+
+            _transactionList = New ListView With {
+                .View = View.Details,
+                .FullRowSelect = True,
+                .Left = 20,
+                .Top = 45,
+                .Width = 600,
+                .Height = 580
+            }
+            _transactionList.Columns.Add("Datum", 100)
+            _transactionList.Columns.Add("Gegenpartei", 160)
+            _transactionList.Columns.Add("Verwendungszweck", 220)
+            _transactionList.Columns.Add("Betrag", 100)
+
+            _chart = New Chart With {
+                .Left = 640,
+                .Top = 45,
+                .Width = 320,
+                .Height = 300
+            }
+            _chart.ChartAreas.Add(New ChartArea("History"))
+            Dim series = New Series("Saldo") With {
+                .ChartType = SeriesChartType.Line
+            }
+            _chart.Series.Add(series)
+
+            Controls.Add(filterLabel)
+            Controls.Add(_fromPicker)
+            Controls.Add(_toPicker)
+            Controls.Add(applyButton)
+            Controls.Add(addTransactionButton)
+            Controls.Add(_transactionList)
+            Controls.Add(_chart)
+
+            _fromPicker.Value = Date.Today.AddMonths(-6)
+            _toPicker.Value = Date.Today
+
+            LoadTransactions()
+            LoadChart()
+        End Sub
+
+        Private Sub LoadTransactions()
+            _transactionList.Items.Clear()
+            Dim transactions = _transactionRepository.GetTransactions(_account.Id, _fromPicker.Value.Date, _toPicker.Value.Date)
+            For Each entry In transactions
+                Dim item = New ListViewItem(entry.BookingDate.ToString("d", CultureInfo.GetCultureInfo("de-DE")))
+                item.SubItems.Add(entry.Counterparty)
+                item.SubItems.Add(entry.Purpose)
+                item.SubItems.Add(entry.Amount.ToString("C", CultureInfo.GetCultureInfo("de-DE")))
+                _transactionList.Items.Add(item)
+            Next
+        End Sub
+
+        Private Sub LoadChart()
+            Dim balances = _transactionRepository.GetMonthlyBalances(_account.Id)
+            Dim series = _chart.Series("Saldo")
+            series.Points.Clear()
+            For Each entry In balances
+                Dim point = series.Points.AddY(entry.Value)
+                point.AxisLabel = entry.Key.ToString("MMM yyyy", CultureInfo.GetCultureInfo("de-DE"))
+            Next
+        End Sub
+
+        Private Sub OnApplyFilter(sender As Object, e As EventArgs)
+            LoadTransactions()
+        End Sub
+
+        Private Sub OnAddTransaction(sender As Object, e As EventArgs)
+            Using dialog As New TransactionEntryForm(_account)
+                If dialog.ShowDialog() <> DialogResult.OK Then
+                    Return
+                End If
+
+                Dim transaction = dialog.GetTransaction()
+                _transactionRepository.AddTransaction(transaction)
+                _account.CurrentBalance += transaction.Amount
+                _accountRepository.UpdateBalance(_account.Id, _account.CurrentBalance)
+            End Using
+
+            LoadTransactions()
+            LoadChart()
+        End Sub
+    End Class
+End Namespace

--- a/BankAssets/Forms/AddAccountForm.vb
+++ b/BankAssets/Forms/AddAccountForm.vb
@@ -1,0 +1,82 @@
+Imports System.Linq
+Imports System.Windows.Forms
+
+Namespace BankAssets.Forms
+    Public Class AddAccountForm
+        Inherits Form
+
+        Private ReadOnly _templates As List(Of Models.BankTemplate)
+        Private ReadOnly _bankCombo As ComboBox
+        Private ReadOnly _bankNameBox As TextBox
+        Private ReadOnly _accountNameBox As TextBox
+        Private ReadOnly _ibanBox As TextBox
+
+        Public Sub New(templates As List(Of Models.BankTemplate))
+            _templates = templates
+
+            Text = "Konto hinzufügen"
+            Width = 460
+            Height = 320
+            StartPosition = FormStartPosition.CenterParent
+
+            Dim templateLabel = New Label With {.Text = "Bankvorlage", .Left = 20, .Top = 20, .AutoSize = True}
+            _bankCombo = New ComboBox With {.Left = 150, .Top = 16, .Width = 250, .DropDownStyle = ComboBoxStyle.DropDownList}
+            _bankCombo.Items.AddRange(_templates.Cast(Of Object).ToArray())
+            _bankCombo.Items.Add("Benutzerdefiniert")
+            _bankCombo.SelectedIndex = 0
+            AddHandler _bankCombo.SelectedIndexChanged, AddressOf OnTemplateChanged
+
+            Dim bankNameLabel = New Label With {.Text = "Bankname", .Left = 20, .Top = 60, .AutoSize = True}
+            _bankNameBox = New TextBox With {.Left = 150, .Top = 56, .Width = 250, .Enabled = False}
+
+            Dim accountNameLabel = New Label With {.Text = "Kontoname", .Left = 20, .Top = 100, .AutoSize = True}
+            _accountNameBox = New TextBox With {.Left = 150, .Top = 96, .Width = 250}
+
+            Dim ibanLabel = New Label With {.Text = "IBAN", .Left = 20, .Top = 140, .AutoSize = True}
+            _ibanBox = New TextBox With {.Left = 150, .Top = 136, .Width = 250}
+
+            Dim saveButton = New Button With {.Text = "Speichern", .Left = 230, .Top = 200, .DialogResult = DialogResult.OK}
+            AddHandler saveButton.Click, AddressOf OnSave
+
+            Dim cancelButton = New Button With {.Text = "Abbrechen", .Left = 330, .Top = 200, .DialogResult = DialogResult.Cancel}
+
+            Controls.Add(templateLabel)
+            Controls.Add(_bankCombo)
+            Controls.Add(bankNameLabel)
+            Controls.Add(_bankNameBox)
+            Controls.Add(accountNameLabel)
+            Controls.Add(_accountNameBox)
+            Controls.Add(ibanLabel)
+            Controls.Add(_ibanBox)
+            Controls.Add(saveButton)
+            Controls.Add(cancelButton)
+        End Sub
+
+        Public Function GetSelection() As (String, String, String, String)
+            Dim template = TryCast(_bankCombo.SelectedItem, Models.BankTemplate)
+            Dim bankName = If(template Is Nothing, _bankNameBox.Text, template.Name)
+            Dim apiType = If(template Is Nothing, "offline", template.ApiType)
+
+            Return (bankName, apiType, _accountNameBox.Text, _ibanBox.Text)
+        End Function
+
+        Private Sub OnTemplateChanged(sender As Object, e As EventArgs)
+            Dim template = TryCast(_bankCombo.SelectedItem, Models.BankTemplate)
+            If template Is Nothing Then
+                _bankNameBox.Enabled = True
+                _bankNameBox.Text = ""
+            Else
+                _bankNameBox.Enabled = False
+                _bankNameBox.Text = template.Name
+            End If
+        End Sub
+
+        Private Sub OnSave(sender As Object, e As EventArgs)
+            Dim selection = GetSelection()
+            If String.IsNullOrWhiteSpace(selection.Item1) OrElse String.IsNullOrWhiteSpace(selection.Item3) OrElse String.IsNullOrWhiteSpace(selection.Item4) Then
+                MessageBox.Show("Bitte Bankname, Kontoname und IBAN angeben.", "Fehlende Angaben", MessageBoxButtons.OK, MessageBoxIcon.Warning)
+                DialogResult = DialogResult.None
+            End If
+        End Sub
+    End Class
+End Namespace

--- a/BankAssets/Forms/MainForm.vb
+++ b/BankAssets/Forms/MainForm.vb
@@ -1,0 +1,168 @@
+Imports System.Globalization
+Imports System.Linq
+Imports System.Windows.Forms
+Imports System.Windows.Forms.DataVisualization.Charting
+
+Namespace BankAssets.Forms
+    Public Class MainForm
+        Inherits Form
+
+        Private ReadOnly _database As Data.Database
+        Private ReadOnly _settingsService As Services.SettingsService
+        Private ReadOnly _accountRepository As Repositories.AccountRepository
+        Private ReadOnly _bankRepository As Repositories.BankRepository
+        Private ReadOnly _listView As ListView
+        Private ReadOnly _chart As Chart
+
+        Public Sub New(database As Data.Database, settingsService As Services.SettingsService)
+            _database = database
+            _settingsService = settingsService
+            _accountRepository = New Repositories.AccountRepository(database)
+            _bankRepository = New Repositories.BankRepository(database)
+
+            Text = "Vermögensübersicht"
+            Width = 1000
+            Height = 700
+            StartPosition = FormStartPosition.CenterScreen
+
+            Dim addAccountButton = New Button With {
+                .Text = "Offline-Konto hinzufügen",
+                .Top = 15,
+                .Left = 20,
+                .Width = 200
+            }
+            AddHandler addAccountButton.Click, AddressOf OnAddOfflineAccount
+
+            _listView = New ListView With {
+                .View = View.Details,
+                .FullRowSelect = True,
+                .Left = 20,
+                .Top = 55,
+                .Width = 520,
+                .Height = 580
+            }
+            _listView.Columns.Add("Konto", 180)
+            _listView.Columns.Add("IBAN", 180)
+            _listView.Columns.Add("Saldo", 120)
+            AddHandler _listView.DoubleClick, AddressOf OnAccountDoubleClick
+
+            _chart = New Chart With {
+                .Left = 560,
+                .Top = 55,
+                .Width = 400,
+                .Height = 400
+            }
+            _chart.ChartAreas.Add(New ChartArea("Assets"))
+            Dim series = New Series("Banks") With {
+                .ChartType = SeriesChartType.Pie
+            }
+            _chart.Series.Add(series)
+
+            Controls.Add(addAccountButton)
+            Controls.Add(_listView)
+            Controls.Add(_chart)
+
+            LoadAccounts()
+        End Sub
+
+        Private Sub LoadAccounts()
+            _listView.Items.Clear()
+            _listView.Groups.Clear()
+            Dim accounts = _accountRepository.GetAccountsWithBank()
+
+            Dim totalsByBank As New Dictionary(Of String, Decimal)
+
+            For Each entry In accounts
+                Dim account = entry.Item1
+                Dim bank = entry.Item2
+                Dim group As ListViewGroup
+
+                If Not _listView.Groups.ContainsKey(bank.Name) Then
+                    group = New ListViewGroup(bank.Name, HorizontalAlignment.Left) With {
+                        .Name = bank.Name
+                    }
+                    _listView.Groups.Add(group)
+                Else
+                    group = _listView.Groups(bank.Name)
+                End If
+
+                Dim item = New ListViewItem(account.Name, group)
+                item.SubItems.Add(account.Iban)
+                item.SubItems.Add(account.CurrentBalance.ToString("C", CultureInfo.GetCultureInfo("de-DE")))
+                item.Tag = account
+                _listView.Items.Add(item)
+
+                If Not totalsByBank.ContainsKey(bank.Name) Then
+                    totalsByBank(bank.Name) = 0
+                End If
+                totalsByBank(bank.Name) += account.CurrentBalance
+            Next
+
+            Dim series = _chart.Series("Banks")
+            series.Points.Clear()
+            For Each entry In totalsByBank
+                Dim point = series.Points.AddY(entry.Value)
+                point.LegendText = entry.Key
+                point.Label = entry.Value.ToString("C", CultureInfo.GetCultureInfo("de-DE"))
+            Next
+        End Sub
+
+        Private Sub OnAccountDoubleClick(sender As Object, e As EventArgs)
+            If _listView.SelectedItems.Count = 0 Then
+                Return
+            End If
+
+            Dim account = CType(_listView.SelectedItems(0).Tag, Models.Account)
+            Using detailForm As New AccountDetailForm(_database, account)
+                detailForm.ShowDialog()
+            End Using
+
+            LoadAccounts()
+        End Sub
+
+        Private Sub OnAddOfflineAccount(sender As Object, e As EventArgs)
+            Using dialog As New AddAccountForm(GetBankTemplates())
+                If dialog.ShowDialog() <> DialogResult.OK Then
+                    Return
+                End If
+
+                Dim selection = dialog.GetSelection()
+                Dim bankName = selection.Item1
+                Dim apiType = selection.Item2
+                Dim accountName = selection.Item3
+                Dim iban = selection.Item4
+
+                Dim bankId As Integer
+                Dim existingBank = _bankRepository.GetAllBanks().FirstOrDefault(Function(b) b.Name.Equals(bankName, StringComparison.OrdinalIgnoreCase))
+                If existingBank Is Nothing Then
+                    bankId = _bankRepository.AddBank(New Models.Bank With {
+                        .Name = bankName,
+                        .ApiType = apiType
+                    })
+                Else
+                    bankId = existingBank.Id
+                End If
+
+                _accountRepository.AddAccount(New Models.Account With {
+                    .BankId = bankId,
+                    .Name = accountName,
+                    .Iban = iban,
+                    .CurrentBalance = 0
+                })
+            End Using
+
+            LoadAccounts()
+        End Sub
+
+        Private Function GetBankTemplates() As List(Of Models.BankTemplate)
+            Return New List(Of Models.BankTemplate) From {
+                New Models.BankTemplate With {.Name = "Deutsche Bank", .ApiType = "offline"},
+                New Models.BankTemplate With {.Name = "Commerzbank", .ApiType = "offline"},
+                New Models.BankTemplate With {.Name = "DKB", .ApiType = "offline"},
+                New Models.BankTemplate With {.Name = "N26", .ApiType = "offline"},
+                New Models.BankTemplate With {.Name = "Sparkasse", .ApiType = "offline"},
+                New Models.BankTemplate With {.Name = "Volksbank/Raiffeisenbank", .ApiType = "offline"}
+            }
+        End Function
+    End Class
+End Namespace

--- a/BankAssets/Forms/SetupForm.vb
+++ b/BankAssets/Forms/SetupForm.vb
@@ -1,0 +1,84 @@
+Imports System.IO
+Imports System.Windows.Forms
+
+Namespace BankAssets.Forms
+    Public Class SetupForm
+        Inherits Form
+
+        Private ReadOnly _settingsService As Services.SettingsService
+        Private ReadOnly _pathTextBox As TextBox
+
+        Public Sub New(settingsService As Services.SettingsService)
+            _settingsService = settingsService
+
+            Text = "Datenbank einrichten"
+            Width = 560
+            Height = 180
+            StartPosition = FormStartPosition.CenterScreen
+
+            Dim instructionLabel = New Label With {
+                .Text = "Bitte wählen Sie den Ordner für die SQLite-Datenbank aus.",
+                .AutoSize = True,
+                .Top = 20,
+                .Left = 20
+            }
+
+            _pathTextBox = New TextBox With {
+                .Left = 20,
+                .Top = 55,
+                .Width = 400,
+                .ReadOnly = True
+            }
+
+            Dim browseButton = New Button With {
+                .Text = "Durchsuchen...",
+                .Left = 430,
+                .Top = 52,
+                .Width = 100
+            }
+            AddHandler browseButton.Click, AddressOf OnBrowseClicked
+
+            Dim saveButton = New Button With {
+                .Text = "Speichern",
+                .Left = 360,
+                .Top = 95,
+                .Width = 80,
+                .DialogResult = DialogResult.OK
+            }
+            AddHandler saveButton.Click, AddressOf OnSaveClicked
+
+            Dim cancelButton = New Button With {
+                .Text = "Abbrechen",
+                .Left = 450,
+                .Top = 95,
+                .Width = 80,
+                .DialogResult = DialogResult.Cancel
+            }
+
+            Controls.Add(instructionLabel)
+            Controls.Add(_pathTextBox)
+            Controls.Add(browseButton)
+            Controls.Add(saveButton)
+            Controls.Add(cancelButton)
+        End Sub
+
+        Private Sub OnBrowseClicked(sender As Object, e As EventArgs)
+            Using dialog = New FolderBrowserDialog()
+                dialog.Description = "Ordner für die Datenbank auswählen"
+                If dialog.ShowDialog() = DialogResult.OK Then
+                    _pathTextBox.Text = Path.Combine(dialog.SelectedPath, "bank-assets.db")
+                End If
+            End Using
+        End Sub
+
+        Private Sub OnSaveClicked(sender As Object, e As EventArgs)
+            If String.IsNullOrWhiteSpace(_pathTextBox.Text) Then
+                MessageBox.Show("Bitte wählen Sie einen Ordner aus.", "Fehlende Angabe", MessageBoxButtons.OK, MessageBoxIcon.Warning)
+                DialogResult = DialogResult.None
+                Return
+            End If
+
+            _settingsService.SaveDatabasePath(_pathTextBox.Text)
+        End Sub
+    End Class
+End Namespace

--- a/BankAssets/Forms/TransactionEntryForm.vb
+++ b/BankAssets/Forms/TransactionEntryForm.vb
@@ -1,0 +1,71 @@
+Imports System.Globalization
+Imports System.Windows.Forms
+
+Namespace BankAssets.Forms
+    Public Class TransactionEntryForm
+        Inherits Form
+
+        Private ReadOnly _account As Models.Account
+        Private ReadOnly _amountBox As TextBox
+        Private ReadOnly _purposeBox As TextBox
+        Private ReadOnly _counterpartyBox As TextBox
+        Private ReadOnly _datePicker As DateTimePicker
+
+        Public Sub New(account As Models.Account)
+            _account = account
+
+            Text = $"Transaktion - {_account.Name}"
+            Width = 420
+            Height = 280
+            StartPosition = FormStartPosition.CenterParent
+
+            Dim amountLabel = New Label With {.Text = "Betrag", .Left = 20, .Top = 20, .AutoSize = True}
+            _amountBox = New TextBox With {.Left = 150, .Top = 16, .Width = 200}
+
+            Dim purposeLabel = New Label With {.Text = "Verwendungszweck", .Left = 20, .Top = 60, .AutoSize = True}
+            _purposeBox = New TextBox With {.Left = 150, .Top = 56, .Width = 200}
+
+            Dim counterpartyLabel = New Label With {.Text = "Gegenpartei", .Left = 20, .Top = 100, .AutoSize = True}
+            _counterpartyBox = New TextBox With {.Left = 150, .Top = 96, .Width = 200}
+
+            Dim dateLabel = New Label With {.Text = "Datum", .Left = 20, .Top = 140, .AutoSize = True}
+            _datePicker = New DateTimePicker With {.Left = 150, .Top = 136, .Width = 200, .Format = DateTimePickerFormat.Short}
+
+            Dim saveButton = New Button With {.Text = "Speichern", .Left = 190, .Top = 180, .DialogResult = DialogResult.OK}
+            AddHandler saveButton.Click, AddressOf OnSave
+
+            Dim cancelButton = New Button With {.Text = "Abbrechen", .Left = 280, .Top = 180, .DialogResult = DialogResult.Cancel}
+
+            Controls.Add(amountLabel)
+            Controls.Add(_amountBox)
+            Controls.Add(purposeLabel)
+            Controls.Add(_purposeBox)
+            Controls.Add(counterpartyLabel)
+            Controls.Add(_counterpartyBox)
+            Controls.Add(dateLabel)
+            Controls.Add(_datePicker)
+            Controls.Add(saveButton)
+            Controls.Add(cancelButton)
+        End Sub
+
+        Public Function GetTransaction() As Models.AccountTransaction
+            Dim amountValue As Decimal
+            Decimal.TryParse(_amountBox.Text, NumberStyles.Number, CultureInfo.GetCultureInfo("de-DE"), amountValue)
+
+            Return New Models.AccountTransaction With {
+                .AccountId = _account.Id,
+                .Amount = amountValue,
+                .Purpose = _purposeBox.Text,
+                .Counterparty = _counterpartyBox.Text,
+                .BookingDate = _datePicker.Value.Date
+            }
+        End Function
+
+        Private Sub OnSave(sender As Object, e As EventArgs)
+            If String.IsNullOrWhiteSpace(_amountBox.Text) OrElse String.IsNullOrWhiteSpace(_purposeBox.Text) Then
+                MessageBox.Show("Bitte Betrag und Verwendungszweck angeben.", "Fehlende Angaben", MessageBoxButtons.OK, MessageBoxIcon.Warning)
+                DialogResult = DialogResult.None
+            End If
+        End Sub
+    End Class
+End Namespace

--- a/BankAssets/Models/Account.vb
+++ b/BankAssets/Models/Account.vb
@@ -1,0 +1,10 @@
+Namespace BankAssets.Models
+    Public Class Account
+        Public Property Id As Integer
+        Public Property BankId As Integer
+        Public Property Name As String = ""
+        Public Property Iban As String = ""
+        Public Property CurrentBalance As Decimal
+        Public Property LastSyncedAt As DateTime?
+    End Class
+End Namespace

--- a/BankAssets/Models/AccountTransaction.vb
+++ b/BankAssets/Models/AccountTransaction.vb
@@ -1,0 +1,10 @@
+Namespace BankAssets.Models
+    Public Class AccountTransaction
+        Public Property Id As Integer
+        Public Property AccountId As Integer
+        Public Property Amount As Decimal
+        Public Property Purpose As String = ""
+        Public Property BookingDate As DateTime
+        Public Property Counterparty As String = ""
+    End Class
+End Namespace

--- a/BankAssets/Models/Bank.vb
+++ b/BankAssets/Models/Bank.vb
@@ -1,0 +1,7 @@
+Namespace BankAssets.Models
+    Public Class Bank
+        Public Property Id As Integer
+        Public Property Name As String = ""
+        Public Property ApiType As String = ""
+    End Class
+End Namespace

--- a/BankAssets/Models/BankTemplate.vb
+++ b/BankAssets/Models/BankTemplate.vb
@@ -1,0 +1,10 @@
+Namespace BankAssets.Models
+    Public Class BankTemplate
+        Public Property Name As String = ""
+        Public Property ApiType As String = "offline"
+
+        Public Overrides Function ToString() As String
+            Return Name
+        End Function
+    End Class
+End Namespace

--- a/BankAssets/Program.vb
+++ b/BankAssets/Program.vb
@@ -1,0 +1,28 @@
+Imports System
+Imports System.IO
+Imports System.Windows.Forms
+
+Namespace BankAssets
+    Friend Module Program
+        <STAThread>
+        Sub Main()
+            ApplicationConfiguration.Initialize()
+
+            Dim settingsService = New Services.SettingsService(Path.Combine(AppContext.BaseDirectory, "appsettings.json"))
+            Dim dbPath = settingsService.LoadDatabasePath()
+
+            If String.IsNullOrWhiteSpace(dbPath) Then
+                Using setupForm As New Forms.SetupForm(settingsService)
+                    If setupForm.ShowDialog() <> DialogResult.OK Then
+                        Return
+                    End If
+                End Using
+            End If
+
+            Dim database = New Data.Database(settingsService)
+            database.Initialize()
+
+            Application.Run(New Forms.MainForm(database, settingsService))
+        End Sub
+    End Module
+End Namespace

--- a/BankAssets/README.md
+++ b/BankAssets/README.md
@@ -1,0 +1,47 @@
+# BankAssets – Anleitung
+
+## Voraussetzungen
+- .NET 6 SDK für Windows (WinForms)
+- SQLite ist integriert (Microsoft.Data.Sqlite)
+
+## Start der App
+1. Projekt in Visual Studio öffnen und `BankAssets` als Startprojekt wählen.
+2. App starten.
+3. Beim ersten Start erscheint **„Datenbank einrichten“**. Wähle einen Ordner – die Datei `bank-assets.db` wird dort erstellt.
+
+## Konto hinzufügen (inkl. Bank-Vorlagen)
+1. In der Hauptansicht auf **„Offline-Konto hinzufügen“** klicken.
+2. Eine **Bankvorlage** auswählen (z. B. „DKB“, „Sparkasse“) **oder** „Benutzerdefiniert“ wählen und den Banknamen manuell angeben.
+3. Kontoname und IBAN eintragen.
+4. Speichern.
+
+> Alle Daten werden in der SQLite-Datenbank gespeichert und verschlüsselt abgelegt.
+
+## Transaktionen manuell hinzufügen
+1. In der Kontoliste doppelklicken, um die Kontoübersicht zu öffnen.
+2. Auf **„Transaktion hinzufügen“** klicken.
+3. Betrag, Verwendungszweck, Gegenpartei und Datum eintragen.
+4. Speichern.
+
+## Filter für Transaktionen
+- Im Konto-Detailfenster Zeitraum auswählen und **„Anwenden“** klicken.
+
+## Bank-Schnittstellen (API) – falls verfügbar
+Aktuell ist nur der Offline-Modus implementiert. Für echte Bank-APIs brauchst du in der Regel:
+- **Client-ID / Client-Secret** (oder API-Token)
+- **Redirect-URL** (für OAuth-Anmeldung)
+- Freischaltung bei der jeweiligen Bank oder einem PSD2-Aggregator
+
+### Woher bekomme ich die Zugangsdaten?
+- **Direkt bei der Bank**: Viele Banken stellen nur für Geschäftskunden oder nach Registrierung eine API bereit.
+- **PSD2-Aggregatoren** (kostenlos oft eingeschränkt):
+  - *Nordigen/GoCardless* (Free Tier)
+  - *Tink* (Developer Account)
+
+### Wie implementiere ich die Schnittstelle?
+1. In `Services/IBankConnector.vb` eine Implementierung hinzufügen (z. B. `NordigenConnector`).
+2. Authentifizierung anhand der API-Dokumentation implementieren (Client Credentials + OAuth).
+3. In `Services/BankSyncService.vb` den Connector anhand `apiType` zurückgeben.
+4. Beim Erstellen der Bank `ApiType` entsprechend setzen (z. B. `nordigen`).
+
+**Hinweis:** Die aktuelle App nutzt bereits das `apiType`-Feld in der Banktabelle, damit später eine echte Synchronisation ergänzt werden kann.

--- a/BankAssets/Repositories/AccountRepository.vb
+++ b/BankAssets/Repositories/AccountRepository.vb
@@ -1,0 +1,82 @@
+Imports System.Globalization
+Imports System.Linq
+Imports Microsoft.Data.Sqlite
+
+Namespace BankAssets.Repositories
+    Public Class AccountRepository
+        Private ReadOnly _database As Data.Database
+        Private ReadOnly _encryptionService As Services.EncryptionService
+
+        Public Sub New(database As Data.Database)
+            _database = database
+            _encryptionService = database.EncryptionService
+        End Sub
+
+        Public Function GetAccountsWithBank() As List(Of (Models.Account, Models.Bank))
+            Dim results As New List(Of (Models.Account, Models.Bank))
+            Using connection = _database.CreateConnection()
+                connection.Open()
+                Dim command = connection.CreateCommand()
+                command.CommandText = ""
+                command.CommandText &= "SELECT a.id, a.bank_id, a.name, a.iban, a.current_balance, a.last_synced_at, "
+                command.CommandText &= "b.id, b.name, b.api_type "
+                command.CommandText &= "FROM accounts a "
+                command.CommandText &= "INNER JOIN banks b ON b.id = a.bank_id"
+
+                Using reader = command.ExecuteReader()
+                    While reader.Read()
+                        Dim decryptedAccountName = _encryptionService.Decrypt(reader.GetString(2))
+                        Dim decryptedIban = _encryptionService.Decrypt(reader.GetString(3))
+                        Dim decryptedBalance = Decimal.Parse(_encryptionService.Decrypt(reader.GetString(4)), CultureInfo.InvariantCulture)
+                        Dim account = New Models.Account With {
+                            .Id = reader.GetInt32(0),
+                            .BankId = reader.GetInt32(1),
+                            .Name = decryptedAccountName,
+                            .Iban = decryptedIban,
+                            .CurrentBalance = decryptedBalance
+                        }
+                        If Not reader.IsDBNull(5) Then
+                            account.LastSyncedAt = DateTime.Parse(reader.GetString(5))
+                        End If
+
+                        Dim decryptedBankName = _encryptionService.Decrypt(reader.GetString(7))
+                        Dim bank = New Models.Bank With {
+                            .Id = reader.GetInt32(6),
+                            .Name = decryptedBankName,
+                            .ApiType = reader.GetString(8)
+                        }
+                        results.Add((account, bank))
+                    End While
+                End Using
+            End Using
+
+            Return results.OrderBy(Function(entry) entry.Item2.Name).ThenBy(Function(entry) entry.Item1.Name).ToList()
+        End Function
+
+        Public Function AddAccount(account As Models.Account) As Integer
+            Using connection = _database.CreateConnection()
+                connection.Open()
+                Dim command = connection.CreateCommand()
+                command.CommandText = "INSERT INTO accounts (bank_id, name, iban, current_balance, last_synced_at) "
+                command.CommandText &= "VALUES ($bankId, $name, $iban, $balance, $lastSynced); SELECT last_insert_rowid();"
+                command.Parameters.AddWithValue("$bankId", account.BankId)
+                command.Parameters.AddWithValue("$name", _encryptionService.Encrypt(account.Name))
+                command.Parameters.AddWithValue("$iban", _encryptionService.Encrypt(account.Iban))
+                command.Parameters.AddWithValue("$balance", _encryptionService.Encrypt(account.CurrentBalance.ToString(CultureInfo.InvariantCulture)))
+                command.Parameters.AddWithValue("$lastSynced", If(account.LastSyncedAt.HasValue, account.LastSyncedAt.Value.ToString("O"), CType(DBNull.Value, Object)))
+                Return Convert.ToInt32(command.ExecuteScalar())
+            End Using
+        End Function
+
+        Public Sub UpdateBalance(accountId As Integer, balance As Decimal)
+            Using connection = _database.CreateConnection()
+                connection.Open()
+                Dim command = connection.CreateCommand()
+                command.CommandText = "UPDATE accounts SET current_balance = $balance WHERE id = $id"
+                command.Parameters.AddWithValue("$balance", _encryptionService.Encrypt(balance.ToString(CultureInfo.InvariantCulture)))
+                command.Parameters.AddWithValue("$id", accountId)
+                command.ExecuteNonQuery()
+            End Using
+        End Sub
+    End Class
+End Namespace

--- a/BankAssets/Repositories/BankRepository.vb
+++ b/BankAssets/Repositories/BankRepository.vb
@@ -1,0 +1,46 @@
+Imports System.Linq
+Imports Microsoft.Data.Sqlite
+
+Namespace BankAssets.Repositories
+    Public Class BankRepository
+        Private ReadOnly _database As Data.Database
+        Private ReadOnly _encryptionService As Services.EncryptionService
+
+        Public Sub New(database As Data.Database)
+            _database = database
+            _encryptionService = database.EncryptionService
+        End Sub
+
+        Public Function GetAllBanks() As List(Of Models.Bank)
+            Dim results As New List(Of Models.Bank)
+            Using connection = _database.CreateConnection()
+                connection.Open()
+                Dim command = connection.CreateCommand()
+                command.CommandText = "SELECT id, name, api_type FROM banks"
+                Using reader = command.ExecuteReader()
+                    While reader.Read()
+                        Dim decryptedName = _encryptionService.Decrypt(reader.GetString(1))
+                        results.Add(New Models.Bank With {
+                            .Id = reader.GetInt32(0),
+                            .Name = decryptedName,
+                            .ApiType = reader.GetString(2)
+                        })
+                    End While
+                End Using
+            End Using
+
+            Return results.OrderBy(Function(b) b.Name).ToList()
+        End Function
+
+        Public Function AddBank(bank As Models.Bank) As Integer
+            Using connection = _database.CreateConnection()
+                connection.Open()
+                Dim command = connection.CreateCommand()
+                command.CommandText = "INSERT INTO banks (name, api_type) VALUES ($name, $apiType); SELECT last_insert_rowid();"
+                command.Parameters.AddWithValue("$name", _encryptionService.Encrypt(bank.Name))
+                command.Parameters.AddWithValue("$apiType", bank.ApiType)
+                Return Convert.ToInt32(command.ExecuteScalar())
+            End Using
+        End Function
+    End Class
+End Namespace

--- a/BankAssets/Repositories/TransactionRepository.vb
+++ b/BankAssets/Repositories/TransactionRepository.vb
@@ -1,0 +1,81 @@
+Imports System.Globalization
+Imports System.Linq
+Imports Microsoft.Data.Sqlite
+
+Namespace BankAssets.Repositories
+    Public Class TransactionRepository
+        Private ReadOnly _database As Data.Database
+        Private ReadOnly _encryptionService As Services.EncryptionService
+
+        Public Sub New(database As Data.Database)
+            _database = database
+            _encryptionService = database.EncryptionService
+        End Sub
+
+        Public Function GetTransactions(accountId As Integer, fromDate As DateTime?, toDate As DateTime?) As List(Of Models.AccountTransaction)
+            Dim results As New List(Of Models.AccountTransaction)
+            Using connection = _database.CreateConnection()
+                connection.Open()
+                Dim command = connection.CreateCommand()
+                command.CommandText = "SELECT id, account_id, amount, purpose, booking_date, counterparty "
+                command.CommandText &= "FROM transactions WHERE account_id = $accountId"
+                command.Parameters.AddWithValue("$accountId", accountId)
+
+                Using reader = command.ExecuteReader()
+                    While reader.Read()
+                        Dim decryptedAmount = Decimal.Parse(_encryptionService.Decrypt(reader.GetString(2)), CultureInfo.InvariantCulture)
+                        Dim decryptedPurpose = _encryptionService.Decrypt(reader.GetString(3))
+                        Dim decryptedBookingDate = DateTime.Parse(_encryptionService.Decrypt(reader.GetString(4)))
+                        Dim decryptedCounterparty = _encryptionService.Decrypt(reader.GetString(5))
+                        results.Add(New Models.AccountTransaction With {
+                            .Id = reader.GetInt32(0),
+                            .AccountId = reader.GetInt32(1),
+                            .Amount = decryptedAmount,
+                            .Purpose = decryptedPurpose,
+                            .BookingDate = decryptedBookingDate,
+                            .Counterparty = decryptedCounterparty
+                        })
+                    End While
+                End Using
+            End Using
+            Dim filtered = results
+            If fromDate.HasValue Then
+                filtered = filtered.Where(Function(t) t.BookingDate.Date >= fromDate.Value.Date).ToList()
+            End If
+            If toDate.HasValue Then
+                filtered = filtered.Where(Function(t) t.BookingDate.Date <= toDate.Value.Date).ToList()
+            End If
+            Return filtered.OrderByDescending(Function(t) t.BookingDate).ToList()
+        End Function
+
+        Public Sub AddTransaction(transaction As Models.AccountTransaction)
+            Using connection = _database.CreateConnection()
+                connection.Open()
+                Dim command = connection.CreateCommand()
+                command.CommandText = "INSERT INTO transactions (account_id, amount, purpose, booking_date, counterparty) "
+                command.CommandText &= "VALUES ($accountId, $amount, $purpose, $bookingDate, $counterparty)"
+                command.Parameters.AddWithValue("$accountId", transaction.AccountId)
+                command.Parameters.AddWithValue("$amount", _encryptionService.Encrypt(transaction.Amount.ToString(CultureInfo.InvariantCulture)))
+                command.Parameters.AddWithValue("$purpose", _encryptionService.Encrypt(transaction.Purpose))
+                command.Parameters.AddWithValue("$bookingDate", _encryptionService.Encrypt(transaction.BookingDate.ToString("O")))
+                command.Parameters.AddWithValue("$counterparty", _encryptionService.Encrypt(transaction.Counterparty))
+                command.ExecuteNonQuery()
+            End Using
+        End Sub
+
+        Public Function GetMonthlyBalances(accountId As Integer) As Dictionary(Of DateTime, Decimal)
+            Dim balances As New Dictionary(Of DateTime, Decimal)
+            Dim transactions = GetTransactions(accountId, Nothing, Nothing)
+            Dim grouped = transactions.GroupBy(Function(t) New DateTime(t.BookingDate.Year, t.BookingDate.Month, 1)) _
+                .OrderBy(Function(g) g.Key)
+
+            Dim runningTotal As Decimal = 0
+            For Each group In grouped
+                runningTotal += group.Sum(Function(t) t.Amount)
+                balances(group.Key) = runningTotal
+            Next
+
+            Return balances
+        End Function
+    End Class
+End Namespace

--- a/BankAssets/Services/BankSyncService.vb
+++ b/BankAssets/Services/BankSyncService.vb
@@ -1,0 +1,7 @@
+Namespace BankAssets.Services
+    Public Class BankSyncService
+        Public Function GetConnector(apiType As String) As IBankConnector
+            Throw New NotSupportedException($"No connector registered for api type '{apiType}'.")
+        End Function
+    End Class
+End Namespace

--- a/BankAssets/Services/EncryptionService.vb
+++ b/BankAssets/Services/EncryptionService.vb
@@ -1,0 +1,58 @@
+Imports System.Security.Cryptography
+Imports System.Text
+
+Namespace BankAssets.Services
+    Public Class EncryptionService
+        Private ReadOnly _key As Byte()
+
+        Public Sub New(key As Byte())
+            _key = key
+        End Sub
+
+        Public Function Encrypt(plainText As String) As String
+            If String.IsNullOrEmpty(plainText) Then
+                Return ""
+            End If
+
+            Dim nonce(11) As Byte
+            RandomNumberGenerator.Fill(nonce)
+
+            Dim plainBytes = Encoding.UTF8.GetBytes(plainText)
+            Dim cipherBytes(plainBytes.Length - 1) As Byte
+            Dim tag(15) As Byte
+
+            Using aes As New AesGcm(_key)
+                aes.Encrypt(nonce, plainBytes, cipherBytes, tag)
+            End Using
+
+            Dim payload = New Byte(nonce.Length + tag.Length + cipherBytes.Length - 1) {}
+            Buffer.BlockCopy(nonce, 0, payload, 0, nonce.Length)
+            Buffer.BlockCopy(tag, 0, payload, nonce.Length, tag.Length)
+            Buffer.BlockCopy(cipherBytes, 0, payload, nonce.Length + tag.Length, cipherBytes.Length)
+
+            Return Convert.ToBase64String(payload)
+        End Function
+
+        Public Function Decrypt(cipherText As String) As String
+            If String.IsNullOrEmpty(cipherText) Then
+                Return ""
+            End If
+
+            Dim payload = Convert.FromBase64String(cipherText)
+            Dim nonce(11) As Byte
+            Dim tag(15) As Byte
+            Dim cipherBytes(payload.Length - nonce.Length - tag.Length - 1) As Byte
+
+            Buffer.BlockCopy(payload, 0, nonce, 0, nonce.Length)
+            Buffer.BlockCopy(payload, nonce.Length, tag, 0, tag.Length)
+            Buffer.BlockCopy(payload, nonce.Length + tag.Length, cipherBytes, 0, cipherBytes.Length)
+
+            Dim plainBytes(cipherBytes.Length - 1) As Byte
+            Using aes As New AesGcm(_key)
+                aes.Decrypt(nonce, cipherBytes, tag, plainBytes)
+            End Using
+
+            Return Encoding.UTF8.GetString(plainBytes)
+        End Function
+    End Class
+End Namespace

--- a/BankAssets/Services/IBankConnector.vb
+++ b/BankAssets/Services/IBankConnector.vb
@@ -1,0 +1,6 @@
+Namespace BankAssets.Services
+    Public Interface IBankConnector
+        Function GetAccounts() As List(Of Models.Account)
+        Function GetTransactions(account As Models.Account) As List(Of Models.AccountTransaction)
+    End Interface
+End Namespace

--- a/BankAssets/Services/SettingsService.vb
+++ b/BankAssets/Services/SettingsService.vb
@@ -1,0 +1,79 @@
+Imports System.IO
+Imports System.Security.Cryptography
+Imports System.Text.Json
+
+Namespace BankAssets.Services
+    Public Class SettingsService
+        Private ReadOnly _settingsPath As String
+
+        Public Sub New(settingsPath As String)
+            _settingsPath = settingsPath
+        End Sub
+
+        Public Function LoadDatabasePath() As String
+            Dim settings = LoadSettings()
+            If settings Is Nothing Then
+                Return ""
+            End If
+
+            Return settings.DatabasePath
+        End Function
+
+        Public Sub SaveDatabasePath(path As String)
+            Dim settings = LoadSettings()
+            If settings Is Nothing Then
+                settings = New AppSettings()
+            End If
+
+            settings.DatabasePath = path
+            SaveSettings(settings)
+        End Sub
+
+        Public Function GetEncryptionKey() As Byte()
+            Dim settings = LoadSettings()
+            If settings Is Nothing Then
+                settings = New AppSettings()
+            End If
+
+            If String.IsNullOrWhiteSpace(settings.EncryptionKey) Then
+                Dim key(31) As Byte
+                RandomNumberGenerator.Fill(key)
+                settings.EncryptionKey = ProtectKey(key)
+                SaveSettings(settings)
+                Return key
+            End If
+
+            Return UnprotectKey(settings.EncryptionKey)
+        End Function
+
+        Private Function LoadSettings() As AppSettings?
+            If Not File.Exists(_settingsPath) Then
+                Return Nothing
+            End If
+
+            Dim json = File.ReadAllText(_settingsPath)
+            Return JsonSerializer.Deserialize(Of AppSettings)(json)
+        End Function
+
+        Private Sub SaveSettings(settings As AppSettings)
+            Dim json = JsonSerializer.Serialize(settings, New JsonSerializerOptions With {.WriteIndented = True})
+            Directory.CreateDirectory(Path.GetDirectoryName(_settingsPath))
+            File.WriteAllText(_settingsPath, json)
+        End Sub
+
+        Private Shared Function ProtectKey(key As Byte()) As String
+            Dim protectedBytes = ProtectedData.Protect(key, Nothing, DataProtectionScope.CurrentUser)
+            Return Convert.ToBase64String(protectedBytes)
+        End Function
+
+        Private Shared Function UnprotectKey(protectedKey As String) As Byte()
+            Dim protectedBytes = Convert.FromBase64String(protectedKey)
+            Return ProtectedData.Unprotect(protectedBytes, Nothing, DataProtectionScope.CurrentUser)
+        End Function
+
+        Private Class AppSettings
+            Public Property DatabasePath As String = ""
+            Public Property EncryptionKey As String = ""
+        End Class
+    End Class
+End Namespace


### PR DESCRIPTION
### Motivation
- Provide templates and a dedicated UI to add common banks or create manual/offline accounts when no bank API is available.  
- Protect sensitive data (bank names, IBANs, balances, transaction details) at rest by encrypting fields stored in the local SQLite file.  
- Keep the app simple and local-first while enabling future integration of bank connectors via the existing `apiType` field.  

### Description
- Add `EncryptionService` (AES‑GCM) and enhance `SettingsService` with `GetEncryptionKey()` that stores a DPAPI-protected key in `appsettings.json`.  
- Change `Data.Database` to expose an `EncryptionService` instance and initialize schema using `TEXT` columns for fields that are encrypted at rest.  
- Update repositories (`BankRepository`, `AccountRepository`, `TransactionRepository`) to encrypt on write and decrypt on read and perform ordering/filtering in memory on decrypted data.  
- Add bank templates (`Models.BankTemplate`), `AddAccountForm` for template/manual account creation, and a user guide `BankAssets/README.md` with setup and API connector instructions.  

### Testing
- No automated unit or integration tests were executed because the .NET SDK is not available in the environment.  
- `dotnet --version` failed in the environment so `dotnet build` / `dotnet test` were not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69470f8221ac83319a7b4b3a18c93558)