### PR TITLE
Add Android WebView app; ESP32 controller, ATmega node, and PC client examples

### DIFF
--- a/BankAssets/esp32_i2c_alexa/README.md
+++ b/BankAssets/esp32_i2c_alexa/README.md
@@ -1,0 +1,84 @@
+# ESP32-WROOM-32 + Alexa + I2C RGB-Controller
+
+Dieses Beispiel besteht aus mehreren Bausteinen:
+
+- `esp32_controller.ino`: Läuft auf dem ESP32, emuliert eine Philips-Hue-Bridge (Alexa kompatibel), bietet eine Web-API/Web-UI (Handy) und steuert RGB-Werte per I2C.
+- `atmega_rgb_node.ino`: Läuft auf einem ATmega328, nimmt I2C-Kommandos an, speichert die letzte Farbe in EEPROM und steuert eine 5mm-RGB-LED (mit Vorwiderständen!).
+- `pc_app/`: Beispiel einer Windows-Desktop-App (Visual Basic), die per HTTP mit dem ESP32 synchronisiert.
+
+## Hardware
+
+- ESP32-WROOM-32
+- Mehrere Arduino ATmega328 (z. B. Nano/Uno oder Standalone)
+- I2C Pullups (4.7k–10k auf SDA/SCL)
+- RGB-LED 5mm + Vorwiderstände (z. B. 220–330 Ohm pro Kanal)
+
+## I2C-Adressvergabe (Wichtig)
+
+Der ESP32 kann **I2C-Adressen zuweisen**, aber I2C kann nicht mehrere Geräte mit identischer Adresse gleichzeitig verwalten.
+Daher gilt folgende **Vorgehensweise**:
+
+1. Ein ATmega wird erstmalig gestartet (ohne gespeicherte Adresse in EEPROM).
+2. Der ESP32 sendet eine **General Call**-Nachricht (Adresse `0x00`) mit einer neuen Zieladresse.
+3. Der ATmega speichert die neue Adresse in EEPROM und startet den I2C-Slave neu.
+4. **Nur ein unzugewiesener ATmega gleichzeitig einschalten**, damit keine Kollisionen entstehen.
+
+Danach kennt jeder ATmega seine eigene Adresse dauerhaft.
+
+> Hinweis: Der ESP32 ist I2C-Master und benötigt keine eigene Slave-Adresse. Die Adresse `0x08` ist als „erste Adresse“ reserviert, die Nodes starten bei `0x09`.
+
+## Alexa Einrichtung
+
+Der ESP32 emuliert eine Hue-Bridge über die Bibliothek `fauxmoESP`.
+
+1. ESP32 mit WLAN verbinden.
+2. In der Alexa-App Geräte suchen ("Gerät hinzufügen" → "Licht" → "Philips Hue" → "Geräte suchen").
+3. Alexa findet virtuelle Lichter wie `RGB Node 1`, `RGB Node 2`, ...
+4. Helligkeit steuert die LED-Intensität.
+
+## Bibliotheken
+
+- `fauxmoESP` (Alexa Hue-Emulation)
+- `ArduinoJson` (optional, wenn erweitert)
+
+## PC-App (Visual Basic)
+
+Die Beispiel-App liegt unter `pc_app/` und nutzt die REST-API des ESP32.
+
+1. Projekt mit Visual Studio öffnen (`RgbControllerApp.vbproj`).
+2. Starten und die ESP32-IP/Hostname eintragen (z. B. `http://esp32.local:8080`).
+3. Farbe, Effekt und Profile setzen.
+
+## Effekte
+
+- **Solid**, **Flicker**, **Rainbow**, **Pulse** sind integriert.
+- Effekte laufen auf dem ESP32 und werden zyklisch an die Nodes gesendet.
+
+## Synchronisation (Handy + PC)
+
+- Beide Apps sprechen die REST-API des ESP32 an (`http://<ip>:8080/api/state`, `/api/node`, `/api/effect`).
+- Beispiel: Alle 3 Sekunden wird der Zustand geladen und UI aktualisiert.
+- Änderung in einer App wird sofort an den ESP32 geschickt und erscheint in der anderen App nach dem nächsten Poll.
+
+## WLAN-Einrichtung (ähnlich Shelly)
+
+1. Wenn noch kein WLAN gespeichert ist, öffnet der ESP32 einen Hotspot **ESP32-RGB-Setup**.
+2. Mit dem Handy verbinden und im Browser `http://192.168.4.1:8080` öffnen.
+3. SSID/Passwort speichern → ESP32 startet neu und verbindet sich mit dem WLAN.
+
+## Hinweise
+
+- Für jede RGB-LED braucht es PWM-Pins am ATmega (z. B. D3, D5, D6).
+- Ohne Vorwiderstände zerstört man die LED.
+- Die Beispiel-Farbwerte sind fest (Rot). Du kannst Farbsteuerung erweitern (HSV, RGB, etc.).
+
+## Dateien
+
+- `esp32_controller.ino`
+- `atmega_rgb_node.ino`
+- `pc_app/`
+- `android_app/`
+
+## Android-App
+
+Die Android-App lädt die ESP32-Web-UI in einer WebView (Android 9+). Sie ist minimal gehalten und nutzt die vorhandenen Funktionen der Weboberfläche.

--- a/BankAssets/esp32_i2c_alexa/android_app/README.md
+++ b/BankAssets/esp32_i2c_alexa/android_app/README.md
@@ -5,6 +5,7 @@ Diese Android-App bietet eine eigene Oberfläche (ohne WebView) und enthält ein
 ## Funktionen
 
 - Setup‑Screen mit Netzwerkscan (ESP32 automatisch finden)
+- Fallback: Broadcast‑Discovery, falls der normale Scan kein Gerät findet
 - Automatische Erkennung von ESP32‑Geräten über `/api/state`
 - Steuerung von LED‑Knoten (RGB per Slider, On/Off)
 - Effektwahl (solid, flicker, rainbow, pulse)

--- a/BankAssets/esp32_i2c_alexa/android_app/README.md
+++ b/BankAssets/esp32_i2c_alexa/android_app/README.md
@@ -1,0 +1,16 @@
+# Android App (ESP32 RGB Controller)
+
+Ein minimales Android-Client-Projekt (Android 9 / API 28+), das die Web-UI des ESP32 in einer `WebView` anzeigt.
+
+## Funktionen
+
+- URL-Eingabe (z. B. `http://esp32.local:8080`)
+- Öffnet die ESP32-Weboberfläche und übernimmt die Synchronisation über die vorhandene Web-UI.
+
+## Build
+
+1. Ordner `android_app/` in Android Studio öffnen.
+2. Gradle sync ausführen.
+3. App auf einem Gerät (Android 9+) starten.
+
+> Hinweis: Die Web-UI muss erreichbar sein. Gegebenenfalls im gleichen WLAN bleiben.

--- a/BankAssets/esp32_i2c_alexa/android_app/README.md
+++ b/BankAssets/esp32_i2c_alexa/android_app/README.md
@@ -4,7 +4,7 @@ Diese Android-App bietet eine eigene Oberfläche (ohne WebView) und enthält ein
 
 ## Funktionen
 
-- Setup‑Screen mit Netzwerkscan und manueller IP/URL
+- Setup‑Screen mit Netzwerkscan (ESP32 automatisch finden)
 - Automatische Erkennung von ESP32‑Geräten über `/api/state`
 - Steuerung von LED‑Knoten (RGB per Slider, On/Off)
 - Effektwahl (solid, flicker, rainbow, pulse)
@@ -15,4 +15,4 @@ Diese Android-App bietet eine eigene Oberfläche (ohne WebView) und enthält ein
 2. Gradle sync ausführen.
 3. App auf einem Gerät (Android 9+) starten.
 
-> Hinweis: Scan benötigt eine aktive WLAN‑Verbindung. Falls kein Gerät gefunden wird, kann die IP manuell eingetragen werden.
+> Hinweis: Scan benötigt eine aktive WLAN‑Verbindung. Wähle ein gefundenes Gerät aus und tippe auf „Hinzufügen“.

--- a/BankAssets/esp32_i2c_alexa/android_app/README.md
+++ b/BankAssets/esp32_i2c_alexa/android_app/README.md
@@ -1,11 +1,13 @@
 # Android App (ESP32 RGB Controller)
 
-Ein minimales Android-Client-Projekt (Android 9 / API 28+), das die Web-UI des ESP32 in einer `WebView` anzeigt.
+Diese Android-App bietet eine eigene Oberfläche (ohne WebView) und enthält einen Setup‑Screen, der das lokale Netzwerk nach einem ESP32 sucht.
 
 ## Funktionen
 
-- URL-Eingabe (z. B. `http://esp32.local:8080`)
-- Öffnet die ESP32-Weboberfläche und übernimmt die Synchronisation über die vorhandene Web-UI.
+- Setup‑Screen mit Netzwerkscan und manueller IP/URL
+- Automatische Erkennung von ESP32‑Geräten über `/api/state`
+- Steuerung von LED‑Knoten (RGB per Slider, On/Off)
+- Effektwahl (solid, flicker, rainbow, pulse)
 
 ## Build
 
@@ -13,4 +15,4 @@ Ein minimales Android-Client-Projekt (Android 9 / API 28+), das die Web-UI des E
 2. Gradle sync ausführen.
 3. App auf einem Gerät (Android 9+) starten.
 
-> Hinweis: Die Web-UI muss erreichbar sein. Gegebenenfalls im gleichen WLAN bleiben.
+> Hinweis: Scan benötigt eine aktive WLAN‑Verbindung. Falls kein Gerät gefunden wird, kann die IP manuell eingetragen werden.

--- a/BankAssets/esp32_i2c_alexa/android_app/app/build.gradle
+++ b/BankAssets/esp32_i2c_alexa/android_app/app/build.gradle
@@ -1,0 +1,39 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'com.example.esp32rgbcontroller'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId "com.example.esp32rgbcontroller"
+        minSdk 28
+        targetSdk 34
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.11.0'
+}

--- a/BankAssets/esp32_i2c_alexa/android_app/app/proguard-rules.pro
+++ b/BankAssets/esp32_i2c_alexa/android_app/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# ProGuard rules placeholder

--- a/BankAssets/esp32_i2c_alexa/android_app/app/src/main/AndroidManifest.xml
+++ b/BankAssets/esp32_i2c_alexa/android_app/app/src/main/AndroidManifest.xml
@@ -1,10 +1,15 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
     <application
         android:allowBackup="true"
         android:label="ESP32 RGB"
         android:theme="@style/Theme.Esp32Rgb">
+        <activity
+            android:name=".ControlActivity"
+            android:exported="false" />
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/BankAssets/esp32_i2c_alexa/android_app/app/src/main/AndroidManifest.xml
+++ b/BankAssets/esp32_i2c_alexa/android_app/app/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:allowBackup="true"
+        android:label="ESP32 RGB"
+        android:theme="@style/Theme.Esp32Rgb">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/BankAssets/esp32_i2c_alexa/android_app/app/src/main/java/com/example/esp32rgbcontroller/ControlActivity.kt
+++ b/BankAssets/esp32_i2c_alexa/android_app/app/src/main/java/com/example/esp32rgbcontroller/ControlActivity.kt
@@ -1,0 +1,174 @@
+package com.example.esp32rgbcontroller
+
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.widget.ArrayAdapter
+import android.widget.Button
+import android.widget.SeekBar
+import android.widget.Spinner
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import org.json.JSONArray
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.concurrent.Executors
+
+class ControlActivity : AppCompatActivity() {
+    private lateinit var deviceNameText: TextView
+    private lateinit var nodeSpinner: Spinner
+    private lateinit var seekR: SeekBar
+    private lateinit var seekG: SeekBar
+    private lateinit var seekB: SeekBar
+    private lateinit var applyColorButton: Button
+    private lateinit var offButton: Button
+    private lateinit var effectSpinner: Spinner
+    private lateinit var applyEffectButton: Button
+    private lateinit var statusText: TextView
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val executor = Executors.newSingleThreadExecutor()
+    private var baseUrl: String = ""
+    private var availableNodes: List<Int> = emptyList()
+    private var refreshRunnable: Runnable? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_control)
+
+        baseUrl = intent.getStringExtra(EXTRA_BASE_URL) ?: "http://esp32.local:8080"
+
+        deviceNameText = findViewById(R.id.deviceNameText)
+        nodeSpinner = findViewById(R.id.nodeSpinner)
+        seekR = findViewById(R.id.seekR)
+        seekG = findViewById(R.id.seekG)
+        seekB = findViewById(R.id.seekB)
+        applyColorButton = findViewById(R.id.applyColorButton)
+        offButton = findViewById(R.id.offButton)
+        effectSpinner = findViewById(R.id.effectSpinner)
+        applyEffectButton = findViewById(R.id.applyEffectButton)
+        statusText = findViewById(R.id.statusText)
+
+        effectSpinner.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_item, listOf("solid", "flicker", "rainbow", "pulse")).apply {
+            setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+        }
+
+        applyColorButton.setOnClickListener { sendColor(true) }
+        offButton.setOnClickListener { sendColor(false) }
+        applyEffectButton.setOnClickListener { sendEffect() }
+
+        refreshRunnable = Runnable {
+            loadState()
+            mainHandler.postDelayed(refreshRunnable!!, 3000)
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        loadState()
+        refreshRunnable?.let { mainHandler.postDelayed(it, 3000) }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        refreshRunnable?.let { mainHandler.removeCallbacks(it) }
+    }
+
+    private fun loadState() {
+        executor.execute {
+            try {
+                val payload = requestJson("$baseUrl/api/state")
+                val json = JSONObject(payload)
+                val name = json.optString("deviceName", "ESP32")
+                val effect = json.optString("effect", "solid")
+                val available = json.optJSONArray("available") ?: JSONArray()
+                val nodes = json.optJSONArray("nodes") ?: JSONArray()
+
+                availableNodes = buildAvailableList(available)
+                val nodeLabels = availableNodes.map { "LED ${it + 1}" }
+
+                mainHandler.post {
+                    deviceNameText.text = name
+                    nodeSpinner.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_item, nodeLabels).apply {
+                        setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+                    }
+                    val effectIndex = (0 until effectSpinner.count).firstOrNull { effectSpinner.getItemAtPosition(it) == effect } ?: 0
+                    effectSpinner.setSelection(effectIndex)
+                    statusText.text = "Status: OK"
+                }
+
+                if (availableNodes.isNotEmpty()) {
+                    val firstIndex = availableNodes.first()
+                    val node = nodes.optJSONObject(firstIndex)
+                    if (node != null) {
+                        mainHandler.post {
+                            seekR.progress = node.optInt("r", 0)
+                            seekG.progress = node.optInt("g", 0)
+                            seekB.progress = node.optInt("b", 0)
+                        }
+                    }
+                }
+            } catch (ex: Exception) {
+                mainHandler.post { statusText.text = "Status: ${ex.message}" }
+            }
+        }
+    }
+
+    private fun sendColor(turnOn: Boolean) {
+        val idx = nodeSpinner.selectedItemPosition
+        if (idx < 0 || idx >= availableNodes.size) {
+            return
+        }
+        val node = availableNodes[idx]
+        val r = seekR.progress
+        val g = seekG.progress
+        val b = seekB.progress
+        val on = if (turnOn) 1 else 0
+        executor.execute {
+            try {
+                requestJson("$baseUrl/api/node?node=$node&r=$r&g=$g&b=$b&on=$on", true)
+                mainHandler.post { statusText.text = "Status: Farbe gesendet" }
+            } catch (ex: Exception) {
+                mainHandler.post { statusText.text = "Status: ${ex.message}" }
+            }
+        }
+    }
+
+    private fun sendEffect() {
+        val effect = effectSpinner.selectedItem?.toString() ?: "solid"
+        executor.execute {
+            try {
+                requestJson("$baseUrl/api/effect?effect=$effect", true)
+                mainHandler.post { statusText.text = "Status: Effekt gesetzt" }
+            } catch (ex: Exception) {
+                mainHandler.post { statusText.text = "Status: ${ex.message}" }
+            }
+        }
+    }
+
+    private fun buildAvailableList(array: JSONArray): List<Int> {
+        val result = mutableListOf<Int>()
+        for (i in 0 until array.length()) {
+            if (array.optBoolean(i, false)) {
+                result.add(i)
+            }
+        }
+        return result
+    }
+
+    private fun requestJson(endpoint: String, post: Boolean = false): String {
+        val url = URL(endpoint)
+        val conn = url.openConnection() as HttpURLConnection
+        conn.connectTimeout = 1500
+        conn.readTimeout = 1500
+        if (post) {
+            conn.requestMethod = "POST"
+        }
+        conn.inputStream.use { return it.bufferedReader().readText() }
+    }
+
+    companion object {
+        const val EXTRA_BASE_URL = "BASE_URL"
+    }
+}

--- a/BankAssets/esp32_i2c_alexa/android_app/app/src/main/java/com/example/esp32rgbcontroller/MainActivity.kt
+++ b/BankAssets/esp32_i2c_alexa/android_app/app/src/main/java/com/example/esp32rgbcontroller/MainActivity.kt
@@ -15,6 +15,8 @@ import android.widget.ListView
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import org.json.JSONObject
+import java.net.DatagramPacket
+import java.net.DatagramSocket
 import java.net.HttpURLConnection
 import java.net.InetAddress
 import java.net.URL
@@ -111,7 +113,12 @@ class MainActivity : AppCompatActivity() {
         executor.shutdown()
         Thread {
             executor.awaitTermination(60, TimeUnit.SECONDS)
-            updateStatus("Scan abgeschlossen: ${devices.size} Geräte")
+            if (devices.isEmpty()) {
+                updateStatus("Kein Gerät gefunden, starte Broadcast-Suche...")
+                runBroadcastDiscovery()
+            } else {
+                updateStatus("Scan abgeschlossen: ${devices.size} Geräte")
+            }
         }.start()
     }
 
@@ -156,6 +163,44 @@ class MainActivity : AppCompatActivity() {
         mainHandler.post {
             statusText.text = text
         }
+    }
+
+    private fun runBroadcastDiscovery() {
+        val executor = Executors.newSingleThreadExecutor()
+        executor.execute {
+            try {
+                val socket = DatagramSocket()
+                socket.broadcast = true
+                socket.soTimeout = 1500
+
+                val requestData = "ESP32_DISCOVER".toByteArray()
+                val broadcastAddress = InetAddress.getByName("255.255.255.255")
+                val request = DatagramPacket(requestData, requestData.size, broadcastAddress, 4210)
+                socket.send(request)
+
+                val buffer = ByteArray(512)
+                val response = DatagramPacket(buffer, buffer.size)
+                val start = System.currentTimeMillis()
+                while (System.currentTimeMillis() - start < 2000) {
+                    try {
+                        socket.receive(response)
+                        val payload = String(response.data, 0, response.length)
+                        val json = JSONObject(payload)
+                        val name = json.optString("deviceName", "ESP32")
+                        val port = json.optInt("port", 8080)
+                        val ip = response.address.hostAddress
+                        addDevice(DiscoveredDevice("http://$ip:$port", name))
+                    } catch (_: Exception) {
+                        break
+                    }
+                }
+                socket.close()
+                updateStatus("Broadcast abgeschlossen: ${devices.size} Geräte")
+            } catch (ex: Exception) {
+                updateStatus("Broadcast fehlgeschlagen: ${ex.message}")
+            }
+        }
+        executor.shutdown()
     }
 
     private fun intToIp(value: Int): String {

--- a/BankAssets/esp32_i2c_alexa/android_app/app/src/main/java/com/example/esp32rgbcontroller/MainActivity.kt
+++ b/BankAssets/esp32_i2c_alexa/android_app/app/src/main/java/com/example/esp32rgbcontroller/MainActivity.kt
@@ -1,0 +1,36 @@
+package com.example.esp32rgbcontroller
+
+import android.os.Bundle
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.widget.Button
+import android.widget.EditText
+import androidx.appcompat.app.AppCompatActivity
+
+class MainActivity : AppCompatActivity() {
+    private lateinit var urlInput: EditText
+    private lateinit var openButton: Button
+    private lateinit var webView: WebView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        urlInput = findViewById(R.id.urlInput)
+        openButton = findViewById(R.id.openButton)
+        webView = findViewById(R.id.webView)
+
+        webView.webViewClient = WebViewClient()
+        val settings: WebSettings = webView.settings
+        settings.javaScriptEnabled = true
+        settings.domStorageEnabled = true
+
+        openButton.setOnClickListener {
+            val url = urlInput.text.toString().trim().ifEmpty { "http://esp32.local:8080" }
+            webView.loadUrl(url)
+        }
+
+        webView.loadUrl("http://esp32.local:8080")
+    }
+}

--- a/BankAssets/esp32_i2c_alexa/android_app/app/src/main/java/com/example/esp32rgbcontroller/MainActivity.kt
+++ b/BankAssets/esp32_i2c_alexa/android_app/app/src/main/java/com/example/esp32rgbcontroller/MainActivity.kt
@@ -1,36 +1,179 @@
 package com.example.esp32rgbcontroller
 
+import android.content.Context
+import android.content.Intent
+import android.net.wifi.WifiManager
 import android.os.Bundle
-import android.webkit.WebSettings
-import android.webkit.WebView
-import android.webkit.WebViewClient
+import android.os.Handler
+import android.os.Looper
+import android.widget.ArrayAdapter
 import android.widget.Button
 import android.widget.EditText
+import android.widget.ListView
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.InetAddress
+import java.net.URL
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 class MainActivity : AppCompatActivity() {
-    private lateinit var urlInput: EditText
-    private lateinit var openButton: Button
-    private lateinit var webView: WebView
+    private lateinit var statusText: TextView
+    private lateinit var manualIpInput: EditText
+    private lateinit var connectButton: Button
+    private lateinit var scanButton: Button
+    private lateinit var deviceList: ListView
+
+    private val devices = mutableListOf<DiscoveredDevice>()
+    private lateinit var adapter: ArrayAdapter<String>
+    private val mainHandler = Handler(Looper.getMainLooper())
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        urlInput = findViewById(R.id.urlInput)
-        openButton = findViewById(R.id.openButton)
-        webView = findViewById(R.id.webView)
+        statusText = findViewById(R.id.statusText)
+        manualIpInput = findViewById(R.id.manualIpInput)
+        connectButton = findViewById(R.id.connectButton)
+        scanButton = findViewById(R.id.scanButton)
+        deviceList = findViewById(R.id.deviceList)
 
-        webView.webViewClient = WebViewClient()
-        val settings: WebSettings = webView.settings
-        settings.javaScriptEnabled = true
-        settings.domStorageEnabled = true
+        adapter = ArrayAdapter(this, android.R.layout.simple_list_item_1, mutableListOf())
+        deviceList.adapter = adapter
 
-        openButton.setOnClickListener {
-            val url = urlInput.text.toString().trim().ifEmpty { "http://esp32.local:8080" }
-            webView.loadUrl(url)
+        connectButton.setOnClickListener {
+            val manual = manualIpInput.text.toString().trim()
+            if (manual.isNotEmpty()) {
+                openControl(normalizeUrl(manual))
+            }
         }
 
-        webView.loadUrl("http://esp32.local:8080")
+        scanButton.setOnClickListener {
+            startScan()
+        }
+
+        deviceList.setOnItemClickListener { _, _, position, _ ->
+            val selected = devices[position]
+            openControl(selected.baseUrl)
+        }
     }
+
+    private fun openControl(baseUrl: String) {
+        val intent = Intent(this, ControlActivity::class.java)
+        intent.putExtra(ControlActivity.EXTRA_BASE_URL, baseUrl)
+        startActivity(intent)
+    }
+
+    private fun startScan() {
+        statusText.text = "Suche im Netzwerk..."
+        devices.clear()
+        adapter.clear()
+
+        val wifiManager = applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+        val dhcp = wifiManager.dhcpInfo
+        val ip = dhcp.ipAddress
+        val mask = dhcp.netmask
+        if (ip == 0 || mask == 0) {
+            statusText.text = "Keine WLAN-Verbindung gefunden"
+            return
+        }
+
+        val network = ip and mask
+        val broadcast = network or mask.inv()
+        val addresses = ConcurrentLinkedQueue<Int>()
+        for (addr in network + 1 until broadcast) {
+            addresses.add(addr)
+        }
+
+        val executor = Executors.newFixedThreadPool(20)
+        val total = addresses.size
+        var scanned = 0
+
+        repeat(20) {
+            executor.execute {
+                while (true) {
+                    val current = addresses.poll() ?: break
+                    val ipString = intToIp(current)
+                    val baseUrl = "http://$ipString:8080"
+                    if (probeDevice(baseUrl)) {
+                        val name = fetchDeviceName(baseUrl)
+                        addDevice(DiscoveredDevice(baseUrl, name))
+                    }
+                    scanned++
+                    if (scanned % 50 == 0) {
+                        updateStatus("Scan: $scanned/$total")
+                    }
+                }
+            }
+        }
+
+        executor.shutdown()
+        Thread {
+            executor.awaitTermination(60, TimeUnit.SECONDS)
+            updateStatus("Scan abgeschlossen: ${devices.size} Geräte")
+        }.start()
+    }
+
+    private fun probeDevice(baseUrl: String): Boolean {
+        return try {
+            val url = URL("$baseUrl/api/state")
+            val conn = url.openConnection() as HttpURLConnection
+            conn.connectTimeout = 600
+            conn.readTimeout = 600
+            conn.inputStream.use { it.readBytes() }
+            conn.responseCode == 200
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private fun fetchDeviceName(baseUrl: String): String {
+        return try {
+            val url = URL("$baseUrl/api/state")
+            val conn = url.openConnection() as HttpURLConnection
+            conn.connectTimeout = 800
+            conn.readTimeout = 800
+            val payload = conn.inputStream.bufferedReader().readText()
+            val json = JSONObject(payload)
+            json.optString("deviceName", "ESP32")
+        } catch (_: Exception) {
+            "ESP32"
+        }
+    }
+
+    private fun addDevice(device: DiscoveredDevice) {
+        mainHandler.post {
+            if (devices.none { it.baseUrl == device.baseUrl }) {
+                devices.add(device)
+                adapter.add("${device.name} (${device.baseUrl})")
+                adapter.notifyDataSetChanged()
+            }
+        }
+    }
+
+    private fun updateStatus(text: String) {
+        mainHandler.post {
+            statusText.text = text
+        }
+    }
+
+    private fun intToIp(value: Int): String {
+        return InetAddress.getByAddress(
+            byteArrayOf(
+                (value and 0xFF).toByte(),
+                (value shr 8 and 0xFF).toByte(),
+                (value shr 16 and 0xFF).toByte(),
+                (value shr 24 and 0xFF).toByte()
+            )
+        ).hostAddress ?: "0.0.0.0"
+    }
+
+    private fun normalizeUrl(value: String): String {
+        return if (value.startsWith("http")) value else "http://$value"
+    }
+
+    private data class DiscoveredDevice(val baseUrl: String, val name: String)
 }

--- a/BankAssets/esp32_i2c_alexa/android_app/app/src/main/java/com/example/esp32rgbcontroller/MainActivity.kt
+++ b/BankAssets/esp32_i2c_alexa/android_app/app/src/main/java/com/example/esp32rgbcontroller/MainActivity.kt
@@ -2,6 +2,9 @@ package com.example.esp32rgbcontroller
 
 import android.content.Context
 import android.content.Intent
+import android.net.ConnectivityManager
+import android.net.LinkProperties
+import android.net.NetworkCapabilities
 import android.net.wifi.WifiManager
 import android.os.Bundle
 import android.os.Handler
@@ -70,17 +73,14 @@ class MainActivity : AppCompatActivity() {
         addButton.isEnabled = false
         addButton.tag = null
 
-        val wifiManager = applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
-        val dhcp = wifiManager.dhcpInfo
-        val ip = dhcp.ipAddress
-        val mask = dhcp.netmask
-        if (ip == 0 || mask == 0) {
+        val networkInfo = resolveWifiNetwork()
+        if (networkInfo == null) {
             statusText.text = "Keine WLAN-Verbindung gefunden"
             return
         }
 
-        val network = ip and mask
-        val broadcast = network or mask.inv()
+        val network = networkInfo.address and networkInfo.mask
+        val broadcast = network or networkInfo.mask.inv()
         val addresses = ConcurrentLinkedQueue<Int>()
         for (addr in network + 1 until broadcast) {
             addresses.add(addr)
@@ -168,6 +168,48 @@ class MainActivity : AppCompatActivity() {
             )
         ).hostAddress ?: "0.0.0.0"
     }
+
+    private fun resolveWifiNetwork(): NetworkInfo? {
+        val connectivity = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val active = connectivity.activeNetwork ?: return resolveWifiNetworkLegacy()
+        val caps = connectivity.getNetworkCapabilities(active) ?: return resolveWifiNetworkLegacy()
+        if (!caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
+            return null
+        }
+        val link = connectivity.getLinkProperties(active) ?: return resolveWifiNetworkLegacy()
+        val info = resolveIpv4(link)
+        return info ?: resolveWifiNetworkLegacy()
+    }
+
+    private fun resolveIpv4(link: LinkProperties): NetworkInfo? {
+        for (address in link.linkAddresses) {
+            val inet = address.address
+            if (inet is java.net.Inet4Address) {
+                val ipInt = inet.address
+                val ip = (ipInt[0].toInt() and 0xFF) or
+                    ((ipInt[1].toInt() and 0xFF) shl 8) or
+                    ((ipInt[2].toInt() and 0xFF) shl 16) or
+                    ((ipInt[3].toInt() and 0xFF) shl 24)
+                val prefix = address.prefixLength
+                val mask = if (prefix == 0) 0 else (-1 shl (32 - prefix))
+                return NetworkInfo(ip, mask)
+            }
+        }
+        return null
+    }
+
+    private fun resolveWifiNetworkLegacy(): NetworkInfo? {
+        val wifiManager = applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+        val dhcp = wifiManager.dhcpInfo ?: return null
+        val ip = dhcp.ipAddress
+        val mask = dhcp.netmask
+        if (ip == 0 || mask == 0) {
+            return null
+        }
+        return NetworkInfo(ip, mask)
+    }
+
+    private data class NetworkInfo(val address: Int, val mask: Int)
 
     private data class DiscoveredDevice(val baseUrl: String, val name: String)
 }

--- a/BankAssets/esp32_i2c_alexa/android_app/app/src/main/java/com/example/esp32rgbcontroller/MainActivity.kt
+++ b/BankAssets/esp32_i2c_alexa/android_app/app/src/main/java/com/example/esp32rgbcontroller/MainActivity.kt
@@ -8,7 +8,6 @@ import android.os.Handler
 import android.os.Looper
 import android.widget.ArrayAdapter
 import android.widget.Button
-import android.widget.EditText
 import android.widget.ListView
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
@@ -22,10 +21,9 @@ import java.util.concurrent.TimeUnit
 
 class MainActivity : AppCompatActivity() {
     private lateinit var statusText: TextView
-    private lateinit var manualIpInput: EditText
-    private lateinit var connectButton: Button
     private lateinit var scanButton: Button
     private lateinit var deviceList: ListView
+    private lateinit var addButton: Button
 
     private val devices = mutableListOf<DiscoveredDevice>()
     private lateinit var adapter: ArrayAdapter<String>
@@ -36,20 +34,12 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
 
         statusText = findViewById(R.id.statusText)
-        manualIpInput = findViewById(R.id.manualIpInput)
-        connectButton = findViewById(R.id.connectButton)
         scanButton = findViewById(R.id.scanButton)
         deviceList = findViewById(R.id.deviceList)
+        addButton = findViewById(R.id.addButton)
 
         adapter = ArrayAdapter(this, android.R.layout.simple_list_item_1, mutableListOf())
         deviceList.adapter = adapter
-
-        connectButton.setOnClickListener {
-            val manual = manualIpInput.text.toString().trim()
-            if (manual.isNotEmpty()) {
-                openControl(normalizeUrl(manual))
-            }
-        }
 
         scanButton.setOnClickListener {
             startScan()
@@ -57,6 +47,12 @@ class MainActivity : AppCompatActivity() {
 
         deviceList.setOnItemClickListener { _, _, position, _ ->
             val selected = devices[position]
+            addButton.isEnabled = true
+            addButton.tag = selected
+        }
+
+        addButton.setOnClickListener {
+            val selected = addButton.tag as? DiscoveredDevice ?: return@setOnClickListener
             openControl(selected.baseUrl)
         }
     }
@@ -71,6 +67,8 @@ class MainActivity : AppCompatActivity() {
         statusText.text = "Suche im Netzwerk..."
         devices.clear()
         adapter.clear()
+        addButton.isEnabled = false
+        addButton.tag = null
 
         val wifiManager = applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
         val dhcp = wifiManager.dhcpInfo
@@ -169,10 +167,6 @@ class MainActivity : AppCompatActivity() {
                 (value shr 24 and 0xFF).toByte()
             )
         ).hostAddress ?: "0.0.0.0"
-    }
-
-    private fun normalizeUrl(value: String): String {
-        return if (value.startsWith("http")) value else "http://$value"
     }
 
     private data class DiscoveredDevice(val baseUrl: String, val name: String)

--- a/BankAssets/esp32_i2c_alexa/android_app/app/src/main/res/layout/activity_control.xml
+++ b/BankAssets/esp32_i2c_alexa/android_app/app/src/main/res/layout/activity_control.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/deviceNameText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="ESP32"
+            android:textStyle="bold" />
+
+        <Spinner
+            android:id="@+id/nodeSpinner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:text="RGB" />
+
+        <SeekBar
+            android:id="@+id/seekR"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:max="255" />
+
+        <SeekBar
+            android:id="@+id/seekG"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:max="255" />
+
+        <SeekBar
+            android:id="@+id/seekB"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:max="255" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/applyColorButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Set" />
+
+            <Button
+                android:id="@+id/offButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_weight="1"
+                android:text="Off" />
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="Effekt" />
+
+        <Spinner
+            android:id="@+id/effectSpinner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <Button
+            android:id="@+id/applyEffectButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="Effekt anwenden" />
+
+        <TextView
+            android:id="@+id/statusText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="Status: -" />
+    </LinearLayout>
+</ScrollView>

--- a/BankAssets/esp32_i2c_alexa/android_app/app/src/main/res/layout/activity_main.xml
+++ b/BankAssets/esp32_i2c_alexa/android_app/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="12dp"
+        android:orientation="horizontal">
+
+        <EditText
+            android:id="@+id/urlInput"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="http://esp32.local:8080"
+            android:inputType="textUri" />
+
+        <Button
+            android:id="@+id/openButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="Open" />
+    </LinearLayout>
+
+    <WebView
+        android:id="@+id/webView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+</LinearLayout>

--- a/BankAssets/esp32_i2c_alexa/android_app/app/src/main/res/layout/activity_main.xml
+++ b/BankAssets/esp32_i2c_alexa/android_app/app/src/main/res/layout/activity_main.xml
@@ -12,27 +12,12 @@
         android:text="Bereit zum Scannen"
         android:textStyle="bold" />
 
-    <LinearLayout
+    <TextView
+        android:id="@+id/scanHint"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="12dp"
-        android:orientation="horizontal">
-
-        <EditText
-            android:id="@+id/manualIpInput"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:hint="http://192.168.1.50:8080"
-            android:inputType="textUri" />
-
-        <Button
-            android:id="@+id/connectButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:text="Verbinden" />
-    </LinearLayout>
+        android:text="Drücke auf Scan, um ESP32-Geräte im WLAN zu finden." />
 
     <Button
         android:id="@+id/scanButton"
@@ -52,4 +37,12 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1" />
+
+    <Button
+        android:id="@+id/addButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:text="Ausgewähltes Gerät hinzufügen"
+        android:enabled="false" />
 </LinearLayout>

--- a/BankAssets/esp32_i2c_alexa/android_app/app/src/main/res/layout/activity_main.xml
+++ b/BankAssets/esp32_i2c_alexa/android_app/app/src/main/res/layout/activity_main.xml
@@ -2,32 +2,53 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/statusText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Bereit zum Scannen"
+        android:textStyle="bold" />
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="12dp"
+        android:layout_marginTop="12dp"
         android:orientation="horizontal">
 
         <EditText
-            android:id="@+id/urlInput"
+            android:id="@+id/manualIpInput"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:hint="http://esp32.local:8080"
+            android:hint="http://192.168.1.50:8080"
             android:inputType="textUri" />
 
         <Button
-            android:id="@+id/openButton"
+            android:id="@+id/connectButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
-            android:text="Open" />
+            android:text="Verbinden" />
     </LinearLayout>
 
-    <WebView
-        android:id="@+id/webView"
+    <Button
+        android:id="@+id/scanButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:text="Netzwerk nach ESP32 scannen" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Gefundene Geräte" />
+
+    <ListView
+        android:id="@+id/deviceList"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1" />

--- a/BankAssets/esp32_i2c_alexa/android_app/app/src/main/res/values/themes.xml
+++ b/BankAssets/esp32_i2c_alexa/android_app/app/src/main/res/values/themes.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.Esp32Rgb" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:statusBarColor">@android:color/black</item>
+    </style>
+</resources>

--- a/BankAssets/esp32_i2c_alexa/android_app/build.gradle
+++ b/BankAssets/esp32_i2c_alexa/android_app/build.gradle
@@ -1,0 +1,4 @@
+plugins {
+    id 'com.android.application' version '8.1.2' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.10' apply false
+}

--- a/BankAssets/esp32_i2c_alexa/android_app/gradle.properties
+++ b/BankAssets/esp32_i2c_alexa/android_app/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true

--- a/BankAssets/esp32_i2c_alexa/android_app/settings.gradle
+++ b/BankAssets/esp32_i2c_alexa/android_app/settings.gradle
@@ -1,0 +1,17 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "ESP32RgbController"
+include ':app'

--- a/BankAssets/esp32_i2c_alexa/atmega_rgb_node.ino
+++ b/BankAssets/esp32_i2c_alexa/atmega_rgb_node.ino
@@ -10,6 +10,7 @@ constexpr uint8_t EEPROM_COLOR_LOCATION = 4; // 3 Bytes (R,G,B)
 // ===== I2C Protokoll =====
 constexpr uint8_t CMD_SET_RGB = 0x10;       // 3 Bytes: R, G, B
 constexpr uint8_t CMD_SET_OFF = 0x11;       // LED aus
+constexpr uint8_t RESP_STATUS = 0x7E;       // Antwort-Byte bei I2C-Request
 constexpr uint8_t CMD_ASSIGN_ADDRESS = 0xA0; // Payload: 1 Byte neue Adresse (General Call)
 
 // ===== RGB Pins (PWM) =====
@@ -81,6 +82,11 @@ static void onReceive(int count) {
   }
 }
 
+static void onRequest() {
+  // Master fragt Status ab: 1 Byte senden
+  Wire.write(RESP_STATUS);
+}
+
 void setup() {
   pinMode(PIN_R, OUTPUT);
   pinMode(PIN_G, OUTPUT);
@@ -94,6 +100,7 @@ void setup() {
   TWAR = (currentAddress << 1) | 0x01;
 #endif
   Wire.onReceive(onReceive);
+  Wire.onRequest(onRequest);
 
   // Startzustand: aus
   uint8_t r = 0;

--- a/BankAssets/esp32_i2c_alexa/atmega_rgb_node.ino
+++ b/BankAssets/esp32_i2c_alexa/atmega_rgb_node.ino
@@ -1,0 +1,108 @@
+#include <Arduino.h>
+#include <Wire.h>
+#include <EEPROM.h>
+
+// ===== I2C =====
+constexpr uint8_t DEFAULT_ADDRESS = 0x08; // Nur temporär, wird nach der Zuweisung ignoriert
+constexpr uint8_t EEPROM_ADDR_LOCATION = 0; // 1 Byte
+constexpr uint8_t EEPROM_COLOR_LOCATION = 4; // 3 Bytes (R,G,B)
+
+// ===== I2C Protokoll =====
+constexpr uint8_t CMD_SET_RGB = 0x10;       // 3 Bytes: R, G, B
+constexpr uint8_t CMD_SET_OFF = 0x11;       // LED aus
+constexpr uint8_t CMD_ASSIGN_ADDRESS = 0xA0; // Payload: 1 Byte neue Adresse (General Call)
+
+// ===== RGB Pins (PWM) =====
+constexpr uint8_t PIN_R = 3;
+constexpr uint8_t PIN_G = 5;
+constexpr uint8_t PIN_B = 6;
+
+uint8_t currentAddress = DEFAULT_ADDRESS;
+
+static void saveAddress(uint8_t addr) {
+  EEPROM.update(EEPROM_ADDR_LOCATION, addr);
+  currentAddress = addr;
+}
+
+static void loadAddress() {
+  uint8_t stored = EEPROM.read(EEPROM_ADDR_LOCATION);
+  if (stored >= 0x08 && stored <= 0x77) {
+    currentAddress = stored;
+  } else {
+    currentAddress = DEFAULT_ADDRESS;
+  }
+}
+
+static void saveColor(uint8_t r, uint8_t g, uint8_t b) {
+  EEPROM.update(EEPROM_COLOR_LOCATION, r);
+  EEPROM.update(EEPROM_COLOR_LOCATION + 1, g);
+  EEPROM.update(EEPROM_COLOR_LOCATION + 2, b);
+}
+
+static void loadColor(uint8_t &r, uint8_t &g, uint8_t &b) {
+  r = EEPROM.read(EEPROM_COLOR_LOCATION);
+  g = EEPROM.read(EEPROM_COLOR_LOCATION + 1);
+  b = EEPROM.read(EEPROM_COLOR_LOCATION + 2);
+}
+
+static void applyRgb(uint8_t r, uint8_t g, uint8_t b) {
+  analogWrite(PIN_R, r);
+  analogWrite(PIN_G, g);
+  analogWrite(PIN_B, b);
+}
+
+static void onReceive(int count) {
+  if (count <= 0) {
+    return;
+  }
+
+  uint8_t cmd = Wire.read();
+
+  if (cmd == CMD_SET_RGB && count >= 4) {
+    uint8_t r = Wire.read();
+    uint8_t g = Wire.read();
+    uint8_t b = Wire.read();
+    applyRgb(r, g, b);
+    saveColor(r, g, b);
+    return;
+  }
+
+  if (cmd == CMD_SET_OFF) {
+    applyRgb(0, 0, 0);
+    return;
+  }
+
+  if (cmd == CMD_ASSIGN_ADDRESS && count >= 2) {
+    uint8_t newAddr = Wire.read();
+    if (newAddr >= 0x08 && newAddr <= 0x77) {
+      saveAddress(newAddr);
+      Wire.begin(currentAddress);
+    }
+  }
+}
+
+void setup() {
+  pinMode(PIN_R, OUTPUT);
+  pinMode(PIN_G, OUTPUT);
+  pinMode(PIN_B, OUTPUT);
+
+  loadAddress();
+
+  Wire.begin(currentAddress);
+#if defined(TWAR)
+  // General Call aktivieren, damit der ESP32 eine Adresse vergeben kann
+  TWAR = (currentAddress << 1) | 0x01;
+#endif
+  Wire.onReceive(onReceive);
+
+  // Startzustand: aus
+  uint8_t r = 0;
+  uint8_t g = 0;
+  uint8_t b = 0;
+  loadColor(r, g, b);
+  applyRgb(r, g, b);
+}
+
+void loop() {
+  // Keine Logik nötig
+}

--- a/BankAssets/esp32_i2c_alexa/esp32_controller.ino
+++ b/BankAssets/esp32_i2c_alexa/esp32_controller.ino
@@ -23,7 +23,8 @@ constexpr char PREF_ROAM_INTERVAL[] = "roam_int";
 // ===== I2C =====
 constexpr uint8_t I2C_SDA = 21;
 constexpr uint8_t I2C_SCL = 22;
-constexpr uint32_t I2C_SPEED = 400000;
+constexpr uint32_t I2C_SPEED = 100000;
+constexpr uint8_t DEFAULT_NODE_ADDRESS = 0x08;
 
 // ===== I2C Protokoll =====
 // 0x00 = General Call (Adressvergabe)
@@ -78,6 +79,7 @@ DeviceSettings deviceSettings;
 bool nodeAvailable[NODE_COUNT];
 bool nodeWasAvailable[NODE_COUNT];
 bool nodeHasStatus[NODE_COUNT];
+bool autoAssignAttempted = false;
 unsigned long lastNodeScan = 0;
 constexpr unsigned long NODE_SCAN_INTERVAL_MS = 5000;
 bool wifiConnected = false;
@@ -890,8 +892,15 @@ void loop() {
     unsigned long now = millis();
     if (now - lastNodeScan >= NODE_SCAN_INTERVAL_MS) {
       lastNodeScan = now;
+      bool anyAvailable = false;
+      size_t firstMissing = NODE_COUNT;
       for (size_t i = 0; i < NODE_COUNT; ++i) {
         nodeAvailable[i] = probeAddress(nodeAddresses[i]);
+        if (nodeAvailable[i]) {
+          anyAvailable = true;
+        } else if (firstMissing == NODE_COUNT) {
+          firstMissing = i;
+        }
         if (!nodeHasStatus[i] || nodeAvailable[i] != nodeWasAvailable[i]) {
           Serial.print("I2C: LED ");
           Serial.print(i + 1);
@@ -899,6 +908,14 @@ void loop() {
           Serial.println();
           nodeWasAvailable[i] = nodeAvailable[i];
           nodeHasStatus[i] = true;
+        }
+      }
+      if (!anyAvailable && !autoAssignAttempted && firstMissing != NODE_COUNT) {
+        if (probeAddress(DEFAULT_NODE_ADDRESS)) {
+          Serial.print("I2C: Unzugewiesener ATmega gefunden, vergebe Adresse ");
+          Serial.println(nodeAddresses[firstMissing], HEX);
+          assignAddress(nodeAddresses[firstMissing]);
+          autoAssignAttempted = true;
         }
       }
     }

--- a/BankAssets/esp32_i2c_alexa/esp32_controller.ino
+++ b/BankAssets/esp32_i2c_alexa/esp32_controller.ino
@@ -3,6 +3,7 @@
 #include <WebServer.h>
 #include <Wire.h>
 #include <Preferences.h>
+#include <WiFiUdp.h>
 #include <fauxmoESP.h>
 
 // ===== WLAN / Setup =====
@@ -41,6 +42,9 @@ constexpr size_t NODE_COUNT = sizeof(nodeAddresses) / sizeof(nodeAddresses[0]);
 fauxmoESP fauxmo;
 WebServer server(8080);
 Preferences prefs;
+WiFiUDP udp;
+constexpr uint16_t DISCOVERY_PORT = 4210;
+constexpr char DISCOVERY_REQUEST[] = "ESP32_DISCOVER";
 
 struct NodeState {
   uint8_t r;
@@ -852,6 +856,10 @@ void setup() {
 
   fauxmo.onSetState(onFauxmoEvent);
 
+  udp.begin(DISCOVERY_PORT);
+  Serial.print("Discovery UDP aktiv auf Port ");
+  Serial.println(DISCOVERY_PORT);
+
   // Beispiel: Adressvergabe (nur ein unzugewiesener ATmega gleichzeitig einschalten!)
   // assignAddress(0x09);
   // assignAddress(0x0A);
@@ -862,6 +870,17 @@ void loop() {
   fauxmo.handle();
   server.handleClient();
   tickEffects();
+  int packetSize = udp.parsePacket();
+  if (packetSize > 0) {
+    char buffer[64] = {0};
+    int len = udp.read(buffer, sizeof(buffer) - 1);
+    if (len > 0 && String(buffer) == DISCOVERY_REQUEST) {
+      String response = "{\"deviceName\":\"" + deviceSettings.name + "\",\"port\":8080}";
+      udp.beginPacket(udp.remoteIP(), udp.remotePort());
+      udp.write(reinterpret_cast<const uint8_t *>(response.c_str()), response.length());
+      udp.endPacket();
+    }
+  }
   unsigned long now = millis();
   if (now - lastNodeScan >= NODE_SCAN_INTERVAL_MS) {
     lastNodeScan = now;

--- a/BankAssets/esp32_i2c_alexa/esp32_controller.ino
+++ b/BankAssets/esp32_i2c_alexa/esp32_controller.ino
@@ -332,18 +332,34 @@ static void handleWiFiSettings() {
   bool connected = false;
   if (ssid.length() > 0) {
     Serial.println("WLAN: starte Verbindungsversuch");
-    WiFi.disconnect(true);
+    WiFi.disconnect(true, true);
     WiFi.mode(WIFI_STA);
-    WiFi.begin(ssid.c_str(), pass.c_str());
-    unsigned long start = millis();
-    while (WiFi.status() != WL_CONNECTED && millis() - start < 12000) {
-      delay(300);
-      Serial.print(".");
+    WiFi.setSleep(false);
+    WiFi.setAutoReconnect(true);
+    delay(200);
+
+    constexpr int kMaxAttempts = 3;
+    for (int attempt = 1; attempt <= kMaxAttempts && !connected; ++attempt) {
+      Serial.print("WLAN: Versuch ");
+      Serial.print(attempt);
+      Serial.print("/");
+      Serial.println(kMaxAttempts);
+      WiFi.begin(ssid.c_str(), pass.c_str());
+      unsigned long start = millis();
+      while (WiFi.status() != WL_CONNECTED && millis() - start < 20000) {
+        delay(300);
+        Serial.print(".");
+      }
+      Serial.println();
+      connected = WiFi.status() == WL_CONNECTED;
+      Serial.print("WLAN: Status=");
+      Serial.println(connected ? "CONNECTED" : "DISCONNECTED");
+      if (!connected) {
+        WiFi.disconnect(true, true);
+        delay(500);
+      }
     }
-    Serial.println();
-    connected = WiFi.status() == WL_CONNECTED;
-    Serial.print("WLAN: Status=");
-    Serial.println(connected ? "CONNECTED" : "DISCONNECTED");
+
     if (connected && deviceSettings.apEnabled) {
       WiFi.mode(WIFI_AP_STA);
       startAccessPoint();
@@ -719,17 +735,35 @@ static bool connectWiFi() {
   }
   Serial.print("WLAN: verbinde mit SSID=");
   Serial.println(ssid);
+  WiFi.disconnect(true, true);
   WiFi.mode(WIFI_STA);
-  WiFi.begin(ssid.c_str(), pass.c_str());
-  unsigned long start = millis();
-  while (WiFi.status() != WL_CONNECTED && millis() - start < 12000) {
-    delay(300);
-    Serial.print(".");
+  WiFi.setSleep(false);
+  WiFi.setAutoReconnect(true);
+  delay(200);
+
+  bool connected = false;
+  constexpr int kMaxAttempts = 3;
+  for (int attempt = 1; attempt <= kMaxAttempts && !connected; ++attempt) {
+    Serial.print("WLAN: Versuch ");
+    Serial.print(attempt);
+    Serial.print("/");
+    Serial.println(kMaxAttempts);
+    WiFi.begin(ssid.c_str(), pass.c_str());
+    unsigned long start = millis();
+    while (WiFi.status() != WL_CONNECTED && millis() - start < 20000) {
+      delay(300);
+      Serial.print(".");
+    }
+    Serial.println();
+    connected = WiFi.status() == WL_CONNECTED;
+    Serial.print("WLAN: Status=");
+    Serial.println(connected ? "CONNECTED" : "DISCONNECTED");
+    if (!connected) {
+      WiFi.disconnect(true, true);
+      delay(500);
+    }
   }
-  Serial.println();
-  Serial.print("WLAN: Status=");
-  Serial.println(WiFi.status() == WL_CONNECTED ? "CONNECTED" : "DISCONNECTED");
-  return WiFi.status() == WL_CONNECTED;
+  return connected;
 }
 
 static void startAccessPoint() {

--- a/BankAssets/esp32_i2c_alexa/esp32_controller.ino
+++ b/BankAssets/esp32_i2c_alexa/esp32_controller.ino
@@ -297,6 +297,21 @@ static void handleWiFiSettings() {
   server.send(200, "text/plain", "saved");
 }
 
+static void handleWiFiScan() {
+  int count = WiFi.scanNetworks();
+  String json = "{\"networks\":[";
+  for (int i = 0; i < count; ++i) {
+    String ssid = WiFi.SSID(i);
+    int rssi = WiFi.RSSI(i);
+    json += "{\"ssid\":\"" + ssid + "\",\"rssi\":" + String(rssi) + "}";
+    if (i + 1 < count) {
+      json += ",";
+    }
+  }
+  json += "]}";
+  server.send(200, "application/json", json);
+}
+
 static void handleRoamingSettings() {
   if (server.hasArg("rssi")) {
     deviceSettings.roamRssi = server.arg("rssi").toInt();
@@ -467,22 +482,34 @@ static void handleControlPage() {
                 "<meta name='viewport' content='width=device-width, initial-scale=1'>"
                 "<title>ESP32 RGB</title>"
                 "<style>"
-                "body{font-family:Arial;background:#0f1720;color:#e2e8f0;margin:0;padding:24px}"
+                "body{font-family:Arial;background:#0f1720;color:#e2e8f0;margin:0;padding:20px}"
                 ".section{background:#1b232b;border-radius:12px;padding:16px;margin-bottom:16px}"
-                ".row{display:flex;align-items:center;gap:12px;margin:8px 0}"
-                ".label{width:160px;color:#8aa1b2}"
+                ".row{display:flex;align-items:center;gap:12px;margin:8px 0;flex-wrap:wrap}"
+                ".label{width:180px;color:#8aa1b2}"
+                ".row input,.row select{flex:1 1 220px;min-width:180px}"
+                ".buttons{display:flex;gap:8px;flex-wrap:wrap}"
                 "input,select,button{background:#101820;color:#e2e8f0;border:1px solid #2c3640;border-radius:6px;padding:8px}"
                 "button{cursor:pointer}"
                 ".btn{background:#1687c5;border:none;padding:8px 14px;border-radius:6px;color:white}"
                 ".btn-secondary{background:#2a3a45}"
                 ".grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}"
                 ".status{font-size:12px;color:#79c0ff}"
+                "@media (max-width: 860px){"
+                ".grid{grid-template-columns:1fr}"
+                ".label{width:100%}"
+                "body{padding:14px}"
+                "}"
+                "@media (max-width: 520px){"
+                "h2{font-size:20px}"
+                ".section{padding:12px}"
+                ".row{gap:8px}"
+                "}"
                 "</style></head><body>"
                 "<h2>Device settings</h2>"
                 "<div class='section'>"
                 "<div class='row'><div class='label'>Device name</div><input id='deviceName' placeholder='RGB Controller'></div>"
-                "<div class='row'><div class='label'>Reboot device</div><button class='btn' onclick='rebootDevice()'>Reboot</button></div>"
-                "<div class='row'><div class='label'>Factory reset</div><button class='btn' onclick='factoryReset()'>Reset</button></div>"
+                "<div class='row'><div class='label'>Reboot device</div><div class='buttons'><button class='btn' onclick='rebootDevice()'>Reboot</button></div></div>"
+                "<div class='row'><div class='label'>Factory reset</div><div class='buttons'><button class='btn' onclick='factoryReset()'>Reset</button></div></div>"
                 "<div class='row'><div class='label'>Location and time</div><span class='status'>coming soon</span></div>"
                 "<div class='row'><div class='label'>Authentication</div><span class='status'>coming soon</span></div>"
                 "</div>"
@@ -493,7 +520,7 @@ static void handleControlPage() {
                 "<span class='status'>Enable Access Point</span></div>"
                 "<div class='row'><div class='label'>AP SSID</div><input id='apSsid' placeholder='ESP32-RGB-Setup'></div>"
                 "<div class='row'><div class='label'>AP Password</div><input id='apPass' type='password'></div>"
-                "<div class='row'><button class='btn' onclick='saveAp()'>Save settings</button></div>"
+                "<div class='row'><div class='buttons'><button class='btn' onclick='saveAp()'>Save settings</button></div></div>"
                 "</div>"
                 "<div class='section'>"
                 "<h3>Wi-Fi status</h3>"
@@ -506,36 +533,42 @@ static void handleControlPage() {
                 "<div class='grid'>"
                 "<div class='section'>"
                 "<h3>Wi-Fi settings</h3>"
-                "<div class='row'><div class='label'>Network</div><input id='wifiSsidInput'></div>"
+                "<div class='row'><div class='label'>Network</div>"
+                "<select id='wifiSsidSelect'></select>"
+                "<input id='wifiSsidInput' placeholder='SSID (manual)'></div>"
                 "<div class='row'><div class='label'>Password</div><input id='wifiPassInput' type='password'></div>"
-                "<div class='row'><button class='btn' onclick='saveWifi()'>Save settings</button></div>"
+                "<div class='row'><div class='buttons'>"
+                "<button class='btn-secondary' onclick='scanWifi()'>Scan</button>"
+                "<button class='btn' onclick='saveWifi()'>Save settings</button></div></div>"
                 "</div>"
                 "<div class='section'>"
                 "<h3>Wi-Fi roaming</h3>"
                 "<div class='row'><div class='label'>RSSI threshold</div><input id='roamRssi' type='number'></div>"
                 "<div class='row'><div class='label'>Interval (s)</div><input id='roamInterval' type='number'></div>"
-                "<div class='row'><button class='btn' onclick='saveRoaming()'>Save settings</button></div>"
+                "<div class='row'><div class='buttons'><button class='btn' onclick='saveRoaming()'>Save settings</button></div></div>"
                 "</div>"
                 "</div>"
                 "<h2>Lighting</h2>"
                 "<div class='section'>"
                 "<div class='row'><div class='label'>Node</div><select id='node'></select></div>"
                 "<div class='row'><div class='label'>Color</div><input type='color' id='color' value='#ff0000'>"
-                "<button class='btn' onclick='applyColor()'>Set</button><button class='btn-secondary' onclick='setOff()'>Off</button></div>"
+                "<div class='buttons'><button class='btn' onclick='applyColor()'>Set</button><button class='btn-secondary' onclick='setOff()'>Off</button></div></div>"
                 "<div class='row'><div class='label'>Effect</div><select id='effect'>"
                 "<option value='solid'>Solid</option>"
                 "<option value='flicker'>Flicker</option>"
                 "<option value='rainbow'>Rainbow</option>"
                 "<option value='pulse'>Pulse</option>"
-                "</select><button class='btn' onclick='applyEffect()'>Apply</button></div>"
+                "</select><div class='buttons'><button class='btn' onclick='applyEffect()'>Apply</button></div></div>"
                 "<div class='row'><div class='label'>Profile</div><input id='profile'>"
-                "<button class='btn' onclick='saveProfile()'>Save</button>"
-                "<button class='btn-secondary' onclick='loadProfile()'>Load</button></div>"
+                "<div class='buttons'><button class='btn' onclick='saveProfile()'>Save</button>"
+                "<button class='btn-secondary' onclick='loadProfile()'>Load</button></div></div>"
                 "</div>"
                 "<script>"
                 "const nodeCount=" + String(NODE_COUNT) + ";"
                 "const nodeSel=document.getElementById('node');"
                 "for(let i=0;i<nodeCount;i++){let o=document.createElement('option');o.value=i;o.text='Node '+(i+1);nodeSel.appendChild(o);} "
+                "const wifiSelect=document.getElementById('wifiSsidSelect');"
+                "wifiSelect.addEventListener('change',()=>{document.getElementById('wifiSsidInput').value=wifiSelect.value;});"
                 "function fetchState(){fetch('/api/state').then(r=>r.json()).then(s=>{"
                 "document.getElementById('effect').value=s.effect;"
                 "document.getElementById('deviceName').value=s.deviceName||'';"
@@ -555,6 +588,11 @@ static void handleControlPage() {
                 "document.getElementById('roamRssi').value=s.rssi;"
                 "document.getElementById('roamInterval').value=s.interval;"
                 "});}"
+                "function scanWifi(){fetch('/api/wifi/scan').then(r=>r.json()).then(s=>{"
+                "wifiSelect.innerHTML='';"
+                "s.networks.forEach(n=>{const opt=document.createElement('option');opt.value=n.ssid;opt.text=n.ssid+' ('+n.rssi+' dBm)';wifiSelect.appendChild(opt);});"
+                "if(s.networks.length>0){document.getElementById('wifiSsidInput').value=s.networks[0].ssid;}"
+                "});}"
                 "function applyColor(){"
                 "const idx=nodeSel.value;const c=document.getElementById('color').value;"
                 "const r=parseInt(c.substr(1,2),16);const g=parseInt(c.substr(3,2),16);const b=parseInt(c.substr(5,2),16);"
@@ -565,7 +603,7 @@ static void handleControlPage() {
                 "function loadProfile(){const n=document.getElementById('profile').value;fetch(`/api/profile/load?name=${encodeURIComponent(n)}`,{method:'POST'}).then(fetchState);} "
                 "function saveAp(){const en=document.getElementById('apEnabled').checked;const ssid=document.getElementById('apSsid').value;const pass=document.getElementById('apPass').value;"
                 "fetch(`/api/ap?enabled=${en?1:0}&ssid=${encodeURIComponent(ssid)}&pass=${encodeURIComponent(pass)}`,{method:'POST'});}"
-                "function saveWifi(){const ssid=document.getElementById('wifiSsidInput').value;const pass=document.getElementById('wifiPassInput').value;"
+                "function saveWifi(){const ssid=document.getElementById('wifiSsidInput').value||wifiSelect.value;const pass=document.getElementById('wifiPassInput').value;"
                 "fetch(`/api/wifi?ssid=${encodeURIComponent(ssid)}&pass=${encodeURIComponent(pass)}`,{method:'POST'});}"
                 "function saveRoaming(){const rssi=document.getElementById('roamRssi').value;const interval=document.getElementById('roamInterval').value;"
                 "fetch(`/api/roaming?rssi=${encodeURIComponent(rssi)}&interval=${encodeURIComponent(interval)}`,{method:'POST'});}"
@@ -574,7 +612,7 @@ static void handleControlPage() {
                 "function saveDeviceName(){const name=document.getElementById('deviceName').value;"
                 "fetch(`/api/device/name?name=${encodeURIComponent(name)}`,{method:'POST'});}"
                 "document.getElementById('deviceName').addEventListener('change',saveDeviceName);"
-                "setInterval(()=>{fetchState();fetchStatus();},3000);fetchState();fetchStatus();fetchAp();fetchRoaming();"
+                "setInterval(()=>{fetchState();fetchStatus();},3000);fetchState();fetchStatus();fetchAp();fetchRoaming();scanWifi();"
                 "</script></body></html>";
   server.send(200, "text/html", html);
 }
@@ -595,6 +633,7 @@ static void setupWebRoutes() {
   server.on("/api/ap", HTTP_POST, handleApSettings);
   server.on("/api/ap", HTTP_GET, handleApSettings);
   server.on("/api/wifi", HTTP_POST, handleWiFiSettings);
+  server.on("/api/wifi/scan", HTTP_GET, handleWiFiScan);
   server.on("/api/roaming", HTTP_POST, handleRoamingSettings);
   server.on("/api/roaming", HTTP_GET, handleRoamingSettings);
   server.on("/api/status", HTTP_GET, handleWiFiStatus);

--- a/BankAssets/esp32_i2c_alexa/esp32_controller.ino
+++ b/BankAssets/esp32_i2c_alexa/esp32_controller.ino
@@ -310,11 +310,14 @@ static void handleWiFiSettings() {
   String ssid = prefs.getString(PREF_WIFI_SSID, "");
   String pass = prefs.getString(PREF_WIFI_PASS, "");
 
+  Serial.println("WLAN: Speichern der Zugangsdaten");
   if (server.hasArg("ssid")) {
     String incoming = server.arg("ssid");
     if (incoming.length() > 0) {
       ssid = incoming;
       prefs.putString(PREF_WIFI_SSID, ssid);
+      Serial.print("WLAN: neue SSID=");
+      Serial.println(ssid);
     }
   }
   if (server.hasArg("pass")) {
@@ -322,19 +325,25 @@ static void handleWiFiSettings() {
     if (incoming.length() > 0) {
       pass = incoming;
       prefs.putString(PREF_WIFI_PASS, pass);
+      Serial.println("WLAN: neues Passwort gesetzt");
     }
   }
 
   bool connected = false;
   if (ssid.length() > 0) {
+    Serial.println("WLAN: starte Verbindungsversuch");
     WiFi.disconnect(true);
     WiFi.mode(WIFI_STA);
     WiFi.begin(ssid.c_str(), pass.c_str());
     unsigned long start = millis();
     while (WiFi.status() != WL_CONNECTED && millis() - start < 12000) {
       delay(300);
+      Serial.print(".");
     }
+    Serial.println();
     connected = WiFi.status() == WL_CONNECTED;
+    Serial.print("WLAN: Status=");
+    Serial.println(connected ? "CONNECTED" : "DISCONNECTED");
     if (connected && deviceSettings.apEnabled) {
       WiFi.mode(WIFI_AP_STA);
       startAccessPoint();
@@ -705,14 +714,21 @@ static bool connectWiFi() {
   String ssid = prefs.getString(PREF_WIFI_SSID, "");
   String pass = prefs.getString(PREF_WIFI_PASS, "");
   if (ssid.length() == 0) {
+    Serial.println("WLAN: keine gespeicherte SSID gefunden");
     return false;
   }
+  Serial.print("WLAN: verbinde mit SSID=");
+  Serial.println(ssid);
   WiFi.mode(WIFI_STA);
   WiFi.begin(ssid.c_str(), pass.c_str());
   unsigned long start = millis();
   while (WiFi.status() != WL_CONNECTED && millis() - start < 12000) {
     delay(300);
+    Serial.print(".");
   }
+  Serial.println();
+  Serial.print("WLAN: Status=");
+  Serial.println(WiFi.status() == WL_CONNECTED ? "CONNECTED" : "DISCONNECTED");
   return WiFi.status() == WL_CONNECTED;
 }
 

--- a/BankAssets/esp32_i2c_alexa/esp32_controller.ino
+++ b/BankAssets/esp32_i2c_alexa/esp32_controller.ino
@@ -71,6 +71,9 @@ bool apMode = false;
 unsigned long lastEffectTick = 0;
 uint16_t rainbowHue = 0;
 DeviceSettings deviceSettings;
+bool nodeAvailable[NODE_COUNT];
+unsigned long lastNodeScan = 0;
+constexpr unsigned long NODE_SCAN_INTERVAL_MS = 5000;
 
 static void sendRgb(uint8_t address, uint8_t r, uint8_t g, uint8_t b) {
   Wire.beginTransmission(address);
@@ -79,6 +82,11 @@ static void sendRgb(uint8_t address, uint8_t r, uint8_t g, uint8_t b) {
   Wire.write(g);
   Wire.write(b);
   Wire.endTransmission();
+}
+
+static bool probeAddress(uint8_t address) {
+  Wire.beginTransmission(address);
+  return Wire.endTransmission() == 0;
 }
 
 static void sendOff(uint8_t address) {
@@ -97,6 +105,10 @@ static void assignAddress(uint8_t newAddress) {
 
 static void applyNodeState(size_t index) {
   if (index >= NODE_COUNT) {
+    return;
+  }
+
+  if (!nodeAvailable[index]) {
     return;
   }
 
@@ -161,7 +173,7 @@ static void tickEffects() {
       return;
     case EffectMode::Flicker:
       for (size_t i = 0; i < NODE_COUNT; ++i) {
-        if (!nodes[i].on) {
+        if (!nodes[i].on || !nodeAvailable[i]) {
           continue;
         }
         uint8_t jitter = random(120, 255);
@@ -171,7 +183,7 @@ static void tickEffects() {
     case EffectMode::Rainbow: {
       rainbowHue = (rainbowHue + 3) % 360;
       for (size_t i = 0; i < NODE_COUNT; ++i) {
-        if (!nodes[i].on) {
+        if (!nodes[i].on || !nodeAvailable[i]) {
           continue;
         }
         uint16_t hue = (rainbowHue + (i * 360 / NODE_COUNT)) % 360;
@@ -184,7 +196,7 @@ static void tickEffects() {
     case EffectMode::Pulse: {
       uint8_t level = static_cast<uint8_t>((sin(now / 400.0) + 1.0) * 120.0);
       for (size_t i = 0; i < NODE_COUNT; ++i) {
-        if (!nodes[i].on) {
+        if (!nodes[i].on || !nodeAvailable[i]) {
           continue;
         }
         sendRgb(nodeAddresses[i], (nodes[i].r * level) / 255, (nodes[i].g * level) / 255, (nodes[i].b * level) / 255);
@@ -232,6 +244,13 @@ static void handleState() {
     json += "\"b\":" + String(nodes[i].b) + ",";
     json += "\"on\":" + String(nodes[i].on ? "true" : "false");
     json += "}";
+    if (i + 1 < NODE_COUNT) {
+      json += ",";
+    }
+  }
+  json += "],\"available\":[";
+  for (size_t i = 0; i < NODE_COUNT; ++i) {
+    json += String(nodeAvailable[i] ? "true" : "false");
     if (i + 1 < NODE_COUNT) {
       json += ",";
     }
@@ -376,6 +395,11 @@ static void handleNodeUpdate() {
   size_t node = static_cast<size_t>(server.arg("node").toInt());
   if (node >= NODE_COUNT) {
     server.send(400, "text/plain", "invalid node");
+    return;
+  }
+
+  if (!nodeAvailable[node]) {
+    server.send(409, "text/plain", "node not available");
     return;
   }
 
@@ -581,7 +605,7 @@ static void handleControlPage() {
                 "</div>"
                 "<h2>Lighting</h2>"
                 "<div class='section'>"
-                "<div class='row'><div class='label'>Node</div><select id='node'></select></div>"
+                "<div class='row'><div class='label'>LED</div><select id='node'></select></div>"
                 "<div class='row'><div class='label'>Color</div><input type='color' id='color' value='#ff0000'>"
                 "<div class='buttons'><button class='btn' onclick='applyColor()'>Set</button><button class='btn-secondary' onclick='setOff()'>Off</button></div></div>"
                 "<div class='row'><div class='label'>Effect</div><select id='effect'>"
@@ -597,12 +621,18 @@ static void handleControlPage() {
                 "<script>"
                 "const nodeCount=" + String(NODE_COUNT) + ";"
                 "const nodeSel=document.getElementById('node');"
-                "for(let i=0;i<nodeCount;i++){let o=document.createElement('option');o.value=i;o.text='Node '+(i+1);nodeSel.appendChild(o);} "
+                "function renderNodes(available){"
+                "nodeSel.innerHTML='';"
+                "available.forEach((isAvailable,idx)=>{"
+                "if(isAvailable){let o=document.createElement('option');o.value=idx;o.text='LED '+(idx+1);nodeSel.appendChild(o);} "
+                "});"
+                "}"
                 "const wifiSelect=document.getElementById('wifiSsidSelect');"
                 "wifiSelect.addEventListener('change',()=>{document.getElementById('wifiSsidInput').value=wifiSelect.value;});"
                 "function fetchState(){fetch('/api/state').then(r=>r.json()).then(s=>{"
                 "document.getElementById('effect').value=s.effect;"
                 "document.getElementById('deviceName').value=s.deviceName||'';"
+                "if(Array.isArray(s.available)){renderNodes(s.available);}"
                 "});}"
                 "function fetchStatus(){fetch('/api/status').then(r=>r.json()).then(s=>{"
                 "document.getElementById('wifiSsid').innerText=s.ssid;"
@@ -729,6 +759,7 @@ void setup() {
 
   for (size_t i = 0; i < NODE_COUNT; ++i) {
     nodes[i] = {255, 0, 0, true};
+    nodeAvailable[i] = false;
   }
 
   deviceSettings.name = prefs.getString(PREF_DEVICE_NAME, "ESP32 RGB Controller");
@@ -775,4 +806,11 @@ void loop() {
   fauxmo.handle();
   server.handleClient();
   tickEffects();
+  unsigned long now = millis();
+  if (now - lastNodeScan >= NODE_SCAN_INTERVAL_MS) {
+    lastNodeScan = now;
+    for (size_t i = 0; i < NODE_COUNT; ++i) {
+      nodeAvailable[i] = probeAddress(nodeAddresses[i]);
+    }
+  }
 }

--- a/BankAssets/esp32_i2c_alexa/esp32_controller.ino
+++ b/BankAssets/esp32_i2c_alexa/esp32_controller.ino
@@ -72,6 +72,7 @@ unsigned long lastEffectTick = 0;
 uint16_t rainbowHue = 0;
 DeviceSettings deviceSettings;
 bool nodeAvailable[NODE_COUNT];
+bool nodeWasAvailable[NODE_COUNT];
 unsigned long lastNodeScan = 0;
 constexpr unsigned long NODE_SCAN_INTERVAL_MS = 5000;
 
@@ -814,6 +815,7 @@ void setup() {
   for (size_t i = 0; i < NODE_COUNT; ++i) {
     nodes[i] = {255, 0, 0, true};
     nodeAvailable[i] = false;
+    nodeWasAvailable[i] = false;
   }
 
   deviceSettings.name = prefs.getString(PREF_DEVICE_NAME, "ESP32 RGB Controller");
@@ -865,6 +867,13 @@ void loop() {
     lastNodeScan = now;
     for (size_t i = 0; i < NODE_COUNT; ++i) {
       nodeAvailable[i] = probeAddress(nodeAddresses[i]);
+      if (nodeAvailable[i] != nodeWasAvailable[i]) {
+        Serial.print("I2C: LED ");
+        Serial.print(i + 1);
+        Serial.print(nodeAvailable[i] ? " verbunden" : " getrennt");
+        Serial.println();
+        nodeWasAvailable[i] = nodeAvailable[i];
+      }
     }
   }
 }

--- a/BankAssets/esp32_i2c_alexa/esp32_controller.ino
+++ b/BankAssets/esp32_i2c_alexa/esp32_controller.ino
@@ -77,6 +77,7 @@ uint16_t rainbowHue = 0;
 DeviceSettings deviceSettings;
 bool nodeAvailable[NODE_COUNT];
 bool nodeWasAvailable[NODE_COUNT];
+bool nodeHasStatus[NODE_COUNT];
 unsigned long lastNodeScan = 0;
 constexpr unsigned long NODE_SCAN_INTERVAL_MS = 5000;
 bool wifiConnected = false;
@@ -821,6 +822,7 @@ void setup() {
     nodes[i] = {255, 0, 0, true};
     nodeAvailable[i] = false;
     nodeWasAvailable[i] = false;
+    nodeHasStatus[i] = false;
   }
 
   deviceSettings.name = prefs.getString(PREF_DEVICE_NAME, "ESP32 RGB Controller");
@@ -890,12 +892,13 @@ void loop() {
       lastNodeScan = now;
       for (size_t i = 0; i < NODE_COUNT; ++i) {
         nodeAvailable[i] = probeAddress(nodeAddresses[i]);
-        if (nodeAvailable[i] != nodeWasAvailable[i]) {
+        if (!nodeHasStatus[i] || nodeAvailable[i] != nodeWasAvailable[i]) {
           Serial.print("I2C: LED ");
           Serial.print(i + 1);
           Serial.print(nodeAvailable[i] ? " verbunden" : " getrennt");
           Serial.println();
           nodeWasAvailable[i] = nodeAvailable[i];
+          nodeHasStatus[i] = true;
         }
       }
     }

--- a/BankAssets/esp32_i2c_alexa/esp32_controller.ino
+++ b/BankAssets/esp32_i2c_alexa/esp32_controller.ino
@@ -79,6 +79,7 @@ bool nodeAvailable[NODE_COUNT];
 bool nodeWasAvailable[NODE_COUNT];
 unsigned long lastNodeScan = 0;
 constexpr unsigned long NODE_SCAN_INTERVAL_MS = 5000;
+bool wifiConnected = false;
 
 static void sendRgb(uint8_t address, uint8_t r, uint8_t g, uint8_t b) {
   Wire.beginTransmission(address);
@@ -829,7 +830,8 @@ void setup() {
   deviceSettings.roamRssi = prefs.getInt(PREF_ROAM_RSSI, -80);
   deviceSettings.roamInterval = prefs.getInt(PREF_ROAM_INTERVAL, 60);
 
-  if (!connectWiFi()) {
+  wifiConnected = connectWiFi();
+  if (!wifiConnected) {
     apMode = true;
     WiFi.mode(WIFI_AP);
     startAccessPoint();
@@ -840,6 +842,7 @@ void setup() {
       WiFi.mode(WIFI_AP_STA);
       startAccessPoint();
     }
+    lastNodeScan = millis() - NODE_SCAN_INTERVAL_MS;
   }
 
   setupWebRoutes();
@@ -881,17 +884,19 @@ void loop() {
       udp.endPacket();
     }
   }
-  unsigned long now = millis();
-  if (now - lastNodeScan >= NODE_SCAN_INTERVAL_MS) {
-    lastNodeScan = now;
-    for (size_t i = 0; i < NODE_COUNT; ++i) {
-      nodeAvailable[i] = probeAddress(nodeAddresses[i]);
-      if (nodeAvailable[i] != nodeWasAvailable[i]) {
-        Serial.print("I2C: LED ");
-        Serial.print(i + 1);
-        Serial.print(nodeAvailable[i] ? " verbunden" : " getrennt");
-        Serial.println();
-        nodeWasAvailable[i] = nodeAvailable[i];
+  if (wifiConnected) {
+    unsigned long now = millis();
+    if (now - lastNodeScan >= NODE_SCAN_INTERVAL_MS) {
+      lastNodeScan = now;
+      for (size_t i = 0; i < NODE_COUNT; ++i) {
+        nodeAvailable[i] = probeAddress(nodeAddresses[i]);
+        if (nodeAvailable[i] != nodeWasAvailable[i]) {
+          Serial.print("I2C: LED ");
+          Serial.print(i + 1);
+          Serial.print(nodeAvailable[i] ? " verbunden" : " getrennt");
+          Serial.println();
+          nodeWasAvailable[i] = nodeAvailable[i];
+        }
       }
     }
   }

--- a/BankAssets/esp32_i2c_alexa/esp32_controller.ino
+++ b/BankAssets/esp32_i2c_alexa/esp32_controller.ino
@@ -85,8 +85,12 @@ static void sendRgb(uint8_t address, uint8_t r, uint8_t g, uint8_t b) {
 }
 
 static bool probeAddress(uint8_t address) {
-  Wire.beginTransmission(address);
-  return Wire.endTransmission() == 0;
+  Wire.requestFrom(static_cast<int>(address), 1);
+  if (Wire.available() <= 0) {
+    return false;
+  }
+  uint8_t value = Wire.read();
+  return value == 0x7E;
 }
 
 static void sendOff(uint8_t address) {

--- a/BankAssets/esp32_i2c_alexa/esp32_controller.ino
+++ b/BankAssets/esp32_i2c_alexa/esp32_controller.ino
@@ -1,0 +1,708 @@
+#include <Arduino.h>
+#include <WiFi.h>
+#include <WebServer.h>
+#include <Wire.h>
+#include <Preferences.h>
+#include <fauxmoESP.h>
+
+// ===== WLAN / Setup =====
+constexpr char SETUP_SSID[] = "ESP32-RGB-Setup";
+constexpr char SETUP_PASS[] = "esp32setup";
+constexpr char PREFS_NAMESPACE[] = "rgbctrl";
+constexpr char PREF_WIFI_SSID[] = "wifi_ssid";
+constexpr char PREF_WIFI_PASS[] = "wifi_pass";
+constexpr char PREF_PROFILES[] = "profiles";
+constexpr char PREF_DEVICE_NAME[] = "device_name";
+constexpr char PREF_AP_ENABLED[] = "ap_enabled";
+constexpr char PREF_AP_SSID[] = "ap_ssid";
+constexpr char PREF_AP_PASS[] = "ap_pass";
+constexpr char PREF_ROAM_RSSI[] = "roam_rssi";
+constexpr char PREF_ROAM_INTERVAL[] = "roam_int";
+
+// ===== I2C =====
+constexpr uint8_t I2C_SDA = 21;
+constexpr uint8_t I2C_SCL = 22;
+constexpr uint32_t I2C_SPEED = 400000;
+
+// ===== I2C Protokoll =====
+// 0x00 = General Call (Adressvergabe)
+// 0x10 = RGB-Set (3 Bytes: R, G, B)
+// 0x11 = Off (LED aus)
+constexpr uint8_t CMD_SET_RGB = 0x10;
+constexpr uint8_t CMD_SET_OFF = 0x11;
+constexpr uint8_t CMD_ASSIGN_ADDRESS = 0xA0; // Payload: 1 Byte neue Adresse
+
+// ===== Geräte =====
+// Der ESP32 selbst benötigt keine I2C-Adresse, 0x08 bleibt reserviert.
+// Liste der zugewiesenen Adressen (Beispiel: 0x09, 0x0A, 0x0B ...)
+uint8_t nodeAddresses[] = {0x09, 0x0A, 0x0B};
+constexpr size_t NODE_COUNT = sizeof(nodeAddresses) / sizeof(nodeAddresses[0]);
+
+fauxmoESP fauxmo;
+WebServer server(8080);
+Preferences prefs;
+
+struct NodeState {
+  uint8_t r;
+  uint8_t g;
+  uint8_t b;
+  bool on;
+};
+
+struct DeviceSettings {
+  String name;
+  bool apEnabled;
+  String apSsid;
+  String apPass;
+  int roamRssi;
+  int roamInterval;
+};
+
+enum class EffectMode : uint8_t {
+  Solid = 0,
+  Flicker = 1,
+  Rainbow = 2,
+  Pulse = 3,
+};
+
+NodeState nodes[NODE_COUNT];
+EffectMode currentEffect = EffectMode::Solid;
+bool apMode = false;
+unsigned long lastEffectTick = 0;
+uint16_t rainbowHue = 0;
+DeviceSettings deviceSettings;
+
+static void sendRgb(uint8_t address, uint8_t r, uint8_t g, uint8_t b) {
+  Wire.beginTransmission(address);
+  Wire.write(CMD_SET_RGB);
+  Wire.write(r);
+  Wire.write(g);
+  Wire.write(b);
+  Wire.endTransmission();
+}
+
+static void sendOff(uint8_t address) {
+  Wire.beginTransmission(address);
+  Wire.write(CMD_SET_OFF);
+  Wire.endTransmission();
+}
+
+// Vergibt eine neue Adresse an einen frisch gestarteten ATmega (nur einer gleichzeitig!)
+static void assignAddress(uint8_t newAddress) {
+  Wire.beginTransmission(0x00); // General Call
+  Wire.write(CMD_ASSIGN_ADDRESS);
+  Wire.write(newAddress);
+  Wire.endTransmission();
+}
+
+static void applyNodeState(size_t index) {
+  if (index >= NODE_COUNT) {
+    return;
+  }
+
+  uint8_t address = nodeAddresses[index];
+  if (!nodes[index].on) {
+    sendOff(address);
+    return;
+  }
+
+  sendRgb(address, nodes[index].r, nodes[index].g, nodes[index].b);
+}
+
+static void applyAllNodes() {
+  for (size_t i = 0; i < NODE_COUNT; ++i) {
+    applyNodeState(i);
+  }
+}
+
+static void setAll(uint8_t r, uint8_t g, uint8_t b) {
+  for (size_t i = 0; i < NODE_COUNT; ++i) {
+    nodes[i].r = r;
+    nodes[i].g = g;
+    nodes[i].b = b;
+    nodes[i].on = true;
+  }
+  applyAllNodes();
+}
+
+static void hsvToRgb(uint16_t hue, uint8_t sat, uint8_t val, uint8_t &outR, uint8_t &outG, uint8_t &outB) {
+  uint8_t region = hue / 60;
+  uint16_t remainder = (hue - (region * 60)) * 255 / 60;
+
+  uint8_t p = (val * (255 - sat)) / 255;
+  uint8_t q = (val * (255 - ((sat * remainder) / 255))) / 255;
+  uint8_t t = (val * (255 - ((sat * (255 - remainder)) / 255))) / 255;
+
+  switch (region) {
+    case 0:
+      outR = val; outG = t; outB = p; break;
+    case 1:
+      outR = q; outG = val; outB = p; break;
+    case 2:
+      outR = p; outG = val; outB = t; break;
+    case 3:
+      outR = p; outG = q; outB = val; break;
+    case 4:
+      outR = t; outG = p; outB = val; break;
+    default:
+      outR = val; outG = p; outB = q; break;
+  }
+}
+
+static void tickEffects() {
+  unsigned long now = millis();
+  if (now - lastEffectTick < 80) {
+    return;
+  }
+  lastEffectTick = now;
+
+  switch (currentEffect) {
+    case EffectMode::Solid:
+      return;
+    case EffectMode::Flicker:
+      for (size_t i = 0; i < NODE_COUNT; ++i) {
+        if (!nodes[i].on) {
+          continue;
+        }
+        uint8_t jitter = random(120, 255);
+        sendRgb(nodeAddresses[i], (nodes[i].r * jitter) / 255, (nodes[i].g * jitter) / 255, (nodes[i].b * jitter) / 255);
+      }
+      return;
+    case EffectMode::Rainbow: {
+      rainbowHue = (rainbowHue + 3) % 360;
+      for (size_t i = 0; i < NODE_COUNT; ++i) {
+        if (!nodes[i].on) {
+          continue;
+        }
+        uint16_t hue = (rainbowHue + (i * 360 / NODE_COUNT)) % 360;
+        uint8_t r, g, b;
+        hsvToRgb(hue, 255, 180, r, g, b);
+        sendRgb(nodeAddresses[i], r, g, b);
+      }
+      return;
+    }
+    case EffectMode::Pulse: {
+      uint8_t level = static_cast<uint8_t>((sin(now / 400.0) + 1.0) * 120.0);
+      for (size_t i = 0; i < NODE_COUNT; ++i) {
+        if (!nodes[i].on) {
+          continue;
+        }
+        sendRgb(nodeAddresses[i], (nodes[i].r * level) / 255, (nodes[i].g * level) / 255, (nodes[i].b * level) / 255);
+      }
+      return;
+    }
+  }
+}
+
+static String effectName() {
+  switch (currentEffect) {
+    case EffectMode::Solid:
+      return "solid";
+    case EffectMode::Flicker:
+      return "flicker";
+    case EffectMode::Rainbow:
+      return "rainbow";
+    case EffectMode::Pulse:
+      return "pulse";
+  }
+  return "solid";
+}
+
+static void setEffectByName(const String &name) {
+  if (name == "flicker") {
+    currentEffect = EffectMode::Flicker;
+  } else if (name == "rainbow") {
+    currentEffect = EffectMode::Rainbow;
+  } else if (name == "pulse") {
+    currentEffect = EffectMode::Pulse;
+  } else {
+    currentEffect = EffectMode::Solid;
+  }
+}
+
+static void handleState() {
+  String json = "{";
+  json += "\"effect\":\"" + effectName() + "\",";
+  json += "\"deviceName\":\"" + deviceSettings.name + "\",";
+  json += "\"nodes\":[";
+  for (size_t i = 0; i < NODE_COUNT; ++i) {
+    json += "{";
+    json += "\"r\":" + String(nodes[i].r) + ",";
+    json += "\"g\":" + String(nodes[i].g) + ",";
+    json += "\"b\":" + String(nodes[i].b) + ",";
+    json += "\"on\":" + String(nodes[i].on ? "true" : "false");
+    json += "}";
+    if (i + 1 < NODE_COUNT) {
+      json += ",";
+    }
+  }
+  json += "]}";
+  server.send(200, "application/json", json);
+}
+
+static void handleDeviceName() {
+  if (server.hasArg("name")) {
+    deviceSettings.name = server.arg("name");
+    prefs.putString(PREF_DEVICE_NAME, deviceSettings.name);
+  }
+  server.send(200, "application/json", "{\"name\":\"" + deviceSettings.name + "\"}");
+}
+
+static void handleDeviceReboot() {
+  server.send(200, "text/plain", "rebooting");
+  delay(250);
+  ESP.restart();
+}
+
+static void handleFactoryReset() {
+  prefs.clear();
+  server.send(200, "text/plain", "reset");
+  delay(250);
+  ESP.restart();
+}
+
+static void handleApSettings() {
+  if (server.hasArg("enabled")) {
+    deviceSettings.apEnabled = server.arg("enabled") == "1" || server.arg("enabled") == "true";
+    prefs.putBool(PREF_AP_ENABLED, deviceSettings.apEnabled);
+  }
+  if (server.hasArg("ssid")) {
+    deviceSettings.apSsid = server.arg("ssid");
+    prefs.putString(PREF_AP_SSID, deviceSettings.apSsid);
+  }
+  if (server.hasArg("pass")) {
+    deviceSettings.apPass = server.arg("pass");
+    prefs.putString(PREF_AP_PASS, deviceSettings.apPass);
+  }
+  if (deviceSettings.apEnabled) {
+    WiFi.mode(WIFI_AP_STA);
+    startAccessPoint();
+  } else {
+    WiFi.softAPdisconnect(true);
+  }
+  String json = "{";
+  json += "\"enabled\":" + String(deviceSettings.apEnabled ? "true" : "false") + ",";
+  json += "\"ssid\":\"" + deviceSettings.apSsid + "\"";
+  json += "}";
+  server.send(200, "application/json", json);
+}
+
+static void handleWiFiSettings() {
+  if (server.hasArg("ssid")) {
+    prefs.putString(PREF_WIFI_SSID, server.arg("ssid"));
+  }
+  if (server.hasArg("pass")) {
+    prefs.putString(PREF_WIFI_PASS, server.arg("pass"));
+  }
+  server.send(200, "text/plain", "saved");
+}
+
+static void handleRoamingSettings() {
+  if (server.hasArg("rssi")) {
+    deviceSettings.roamRssi = server.arg("rssi").toInt();
+    prefs.putInt(PREF_ROAM_RSSI, deviceSettings.roamRssi);
+  }
+  if (server.hasArg("interval")) {
+    deviceSettings.roamInterval = server.arg("interval").toInt();
+    prefs.putInt(PREF_ROAM_INTERVAL, deviceSettings.roamInterval);
+  }
+  server.send(200, "application/json", "{\"rssi\":" + String(deviceSettings.roamRssi) + ",\"interval\":" + String(deviceSettings.roamInterval) + "}");
+}
+
+static void handleWiFiStatus() {
+  String json = "{";
+  json += "\"ssid\":\"" + WiFi.SSID() + "\",";
+  json += "\"bssid\":\"" + WiFi.BSSIDstr() + "\",";
+  json += "\"ip\":\"" + WiFi.localIP().toString() + "\",";
+  json += "\"mac\":\"" + WiFi.macAddress() + "\",";
+  json += "\"rssi\":" + String(WiFi.RSSI()) + ",";
+  json += "\"status\":\"" + String(WiFi.status() == WL_CONNECTED ? "connected" : "disconnected") + "\"";
+  json += "}";
+  server.send(200, "application/json", json);
+}
+
+static void handleNodeUpdate() {
+  if (!server.hasArg("node")) {
+    server.send(400, "text/plain", "missing node");
+    return;
+  }
+
+  size_t node = static_cast<size_t>(server.arg("node").toInt());
+  if (node >= NODE_COUNT) {
+    server.send(400, "text/plain", "invalid node");
+    return;
+  }
+
+  if (server.hasArg("r")) nodes[node].r = static_cast<uint8_t>(server.arg("r").toInt());
+  if (server.hasArg("g")) nodes[node].g = static_cast<uint8_t>(server.arg("g").toInt());
+  if (server.hasArg("b")) nodes[node].b = static_cast<uint8_t>(server.arg("b").toInt());
+  if (server.hasArg("on")) nodes[node].on = server.arg("on") == "1" || server.arg("on") == "true";
+
+  applyNodeState(node);
+  handleState();
+}
+
+static void handleEffectUpdate() {
+  if (!server.hasArg("effect")) {
+    server.send(400, "text/plain", "missing effect");
+    return;
+  }
+  setEffectByName(server.arg("effect"));
+  handleState();
+}
+
+static String getProfiles() {
+  return String(prefs.getString(PREF_PROFILES, ""));
+}
+
+static void setProfiles(const String &profiles) {
+  prefs.putString(PREF_PROFILES, profiles);
+}
+
+static void handleProfileSave() {
+  if (!server.hasArg("name")) {
+    server.send(400, "text/plain", "missing name");
+    return;
+  }
+  String name = server.arg("name");
+  String key = "profile_" + name;
+
+  String payload = effectName();
+  for (size_t i = 0; i < NODE_COUNT; ++i) {
+    payload += ",";
+    payload += String(nodes[i].r);
+    payload += ":";
+    payload += String(nodes[i].g);
+    payload += ":";
+    payload += String(nodes[i].b);
+    payload += ":";
+    payload += String(nodes[i].on ? 1 : 0);
+  }
+
+  prefs.putString(key.c_str(), payload);
+
+  String existing = getProfiles();
+  if (existing.indexOf(name) == -1) {
+    if (existing.length() > 0) {
+      existing += ",";
+    }
+    existing += name;
+    setProfiles(existing);
+  }
+
+  server.send(200, "text/plain", "ok");
+}
+
+static void handleProfileLoad() {
+  if (!server.hasArg("name")) {
+    server.send(400, "text/plain", "missing name");
+    return;
+  }
+
+  String key = "profile_" + server.arg("name");
+  String payload = prefs.getString(key.c_str(), "");
+  if (payload.length() == 0) {
+    server.send(404, "text/plain", "not found");
+    return;
+  }
+
+  int start = payload.indexOf(',');
+  String effect = payload.substring(0, start);
+  setEffectByName(effect);
+
+  size_t idx = 0;
+  int cursor = start + 1;
+  while (cursor > 0 && idx < NODE_COUNT) {
+    int next = payload.indexOf(',', cursor);
+    String part = next >= 0 ? payload.substring(cursor, next) : payload.substring(cursor);
+    int p1 = part.indexOf(':');
+    int p2 = part.indexOf(':', p1 + 1);
+    int p3 = part.indexOf(':', p2 + 1);
+    if (p1 > 0 && p2 > p1 && p3 > p2) {
+      nodes[idx].r = static_cast<uint8_t>(part.substring(0, p1).toInt());
+      nodes[idx].g = static_cast<uint8_t>(part.substring(p1 + 1, p2).toInt());
+      nodes[idx].b = static_cast<uint8_t>(part.substring(p2 + 1, p3).toInt());
+      nodes[idx].on = part.substring(p3 + 1).toInt() == 1;
+    }
+    idx++;
+    if (next < 0) {
+      break;
+    }
+    cursor = next + 1;
+  }
+
+  applyAllNodes();
+  handleState();
+}
+
+static void handleProfilesList() {
+  server.send(200, "application/json", "{\"profiles\":\"" + getProfiles() + "\"}");
+}
+
+static void handleSetupPage() {
+  String html = "<!doctype html><html><head><meta charset='utf-8'><meta name='viewport' content='width=device-width, initial-scale=1'>"
+                "<title>ESP32 Setup</title></head><body style='font-family:Arial;background:#101820;color:#f2f4f8;padding:24px'>"
+                "<h1>WLAN Setup</h1>"
+                "<form method='POST' action='/setup'>"
+                "<label>SSID<br><input name='ssid' style='width:260px'></label><br><br>"
+                "<label>Passwort<br><input name='pass' type='password' style='width:260px'></label><br><br>"
+                "<button type='submit'>Speichern</button></form></body></html>";
+  server.send(200, "text/html", html);
+}
+
+static void handleSetupPost() {
+  if (!server.hasArg("ssid")) {
+    server.send(400, "text/plain", "missing ssid");
+    return;
+  }
+  prefs.putString(PREF_WIFI_SSID, server.arg("ssid"));
+  prefs.putString(PREF_WIFI_PASS, server.arg("pass"));
+  server.send(200, "text/plain", "Gespeichert. Neustart...");
+  delay(500);
+  ESP.restart();
+}
+
+static void handleControlPage() {
+  String html = "<!doctype html><html><head><meta charset='utf-8'>"
+                "<meta name='viewport' content='width=device-width, initial-scale=1'>"
+                "<title>ESP32 RGB</title>"
+                "<style>"
+                "body{font-family:Arial;background:#0f1720;color:#e2e8f0;margin:0;padding:24px}"
+                ".section{background:#1b232b;border-radius:12px;padding:16px;margin-bottom:16px}"
+                ".row{display:flex;align-items:center;gap:12px;margin:8px 0}"
+                ".label{width:160px;color:#8aa1b2}"
+                "input,select,button{background:#101820;color:#e2e8f0;border:1px solid #2c3640;border-radius:6px;padding:8px}"
+                "button{cursor:pointer}"
+                ".btn{background:#1687c5;border:none;padding:8px 14px;border-radius:6px;color:white}"
+                ".btn-secondary{background:#2a3a45}"
+                ".grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}"
+                ".status{font-size:12px;color:#79c0ff}"
+                "</style></head><body>"
+                "<h2>Device settings</h2>"
+                "<div class='section'>"
+                "<div class='row'><div class='label'>Device name</div><input id='deviceName' placeholder='RGB Controller'></div>"
+                "<div class='row'><div class='label'>Reboot device</div><button class='btn' onclick='rebootDevice()'>Reboot</button></div>"
+                "<div class='row'><div class='label'>Factory reset</div><button class='btn' onclick='factoryReset()'>Reset</button></div>"
+                "<div class='row'><div class='label'>Location and time</div><span class='status'>coming soon</span></div>"
+                "<div class='row'><div class='label'>Authentication</div><span class='status'>coming soon</span></div>"
+                "</div>"
+                "<h2>Network settings</h2>"
+                "<div class='section'>"
+                "<div class='row'><div class='label'>Access Point</div>"
+                "<input type='checkbox' id='apEnabled' onchange='saveAp()'>"
+                "<span class='status'>Enable Access Point</span></div>"
+                "<div class='row'><div class='label'>AP SSID</div><input id='apSsid' placeholder='ESP32-RGB-Setup'></div>"
+                "<div class='row'><div class='label'>AP Password</div><input id='apPass' type='password'></div>"
+                "<div class='row'><button class='btn' onclick='saveAp()'>Save settings</button></div>"
+                "</div>"
+                "<div class='section'>"
+                "<h3>Wi-Fi status</h3>"
+                "<div class='row'><div class='label'>Network</div><span id='wifiSsid'></span></div>"
+                "<div class='row'><div class='label'>BSSID</div><span id='wifiBssid'></span></div>"
+                "<div class='row'><div class='label'>IPv4 address</div><span id='wifiIp'></span></div>"
+                "<div class='row'><div class='label'>MAC address</div><span id='wifiMac'></span></div>"
+                "<div class='row'><div class='label'>Status</div><span id='wifiStatus'></span></div>"
+                "</div>"
+                "<div class='grid'>"
+                "<div class='section'>"
+                "<h3>Wi-Fi settings</h3>"
+                "<div class='row'><div class='label'>Network</div><input id='wifiSsidInput'></div>"
+                "<div class='row'><div class='label'>Password</div><input id='wifiPassInput' type='password'></div>"
+                "<div class='row'><button class='btn' onclick='saveWifi()'>Save settings</button></div>"
+                "</div>"
+                "<div class='section'>"
+                "<h3>Wi-Fi roaming</h3>"
+                "<div class='row'><div class='label'>RSSI threshold</div><input id='roamRssi' type='number'></div>"
+                "<div class='row'><div class='label'>Interval (s)</div><input id='roamInterval' type='number'></div>"
+                "<div class='row'><button class='btn' onclick='saveRoaming()'>Save settings</button></div>"
+                "</div>"
+                "</div>"
+                "<h2>Lighting</h2>"
+                "<div class='section'>"
+                "<div class='row'><div class='label'>Node</div><select id='node'></select></div>"
+                "<div class='row'><div class='label'>Color</div><input type='color' id='color' value='#ff0000'>"
+                "<button class='btn' onclick='applyColor()'>Set</button><button class='btn-secondary' onclick='setOff()'>Off</button></div>"
+                "<div class='row'><div class='label'>Effect</div><select id='effect'>"
+                "<option value='solid'>Solid</option>"
+                "<option value='flicker'>Flicker</option>"
+                "<option value='rainbow'>Rainbow</option>"
+                "<option value='pulse'>Pulse</option>"
+                "</select><button class='btn' onclick='applyEffect()'>Apply</button></div>"
+                "<div class='row'><div class='label'>Profile</div><input id='profile'>"
+                "<button class='btn' onclick='saveProfile()'>Save</button>"
+                "<button class='btn-secondary' onclick='loadProfile()'>Load</button></div>"
+                "</div>"
+                "<script>"
+                "const nodeCount=" + String(NODE_COUNT) + ";"
+                "const nodeSel=document.getElementById('node');"
+                "for(let i=0;i<nodeCount;i++){let o=document.createElement('option');o.value=i;o.text='Node '+(i+1);nodeSel.appendChild(o);} "
+                "function fetchState(){fetch('/api/state').then(r=>r.json()).then(s=>{"
+                "document.getElementById('effect').value=s.effect;"
+                "document.getElementById('deviceName').value=s.deviceName||'';"
+                "});}"
+                "function fetchStatus(){fetch('/api/status').then(r=>r.json()).then(s=>{"
+                "document.getElementById('wifiSsid').innerText=s.ssid;"
+                "document.getElementById('wifiBssid').innerText=s.bssid;"
+                "document.getElementById('wifiIp').innerText=s.ip;"
+                "document.getElementById('wifiMac').innerText=s.mac;"
+                "document.getElementById('wifiStatus').innerText=s.status+\" (RSSI \"+s.rssi+\" dBm)\";"
+                "});}"
+                "function fetchAp(){fetch('/api/ap').then(r=>r.json()).then(s=>{"
+                "document.getElementById('apEnabled').checked=s.enabled;"
+                "document.getElementById('apSsid').value=s.ssid||'';"
+                "});}"
+                "function fetchRoaming(){fetch('/api/roaming').then(r=>r.json()).then(s=>{"
+                "document.getElementById('roamRssi').value=s.rssi;"
+                "document.getElementById('roamInterval').value=s.interval;"
+                "});}"
+                "function applyColor(){"
+                "const idx=nodeSel.value;const c=document.getElementById('color').value;"
+                "const r=parseInt(c.substr(1,2),16);const g=parseInt(c.substr(3,2),16);const b=parseInt(c.substr(5,2),16);"
+                "fetch(`/api/node?node=${idx}&r=${r}&g=${g}&b=${b}&on=1`,{method:'POST'}).then(fetchState);}"
+                "function setOff(){const idx=nodeSel.value;fetch(`/api/node?node=${idx}&on=0`,{method:'POST'}).then(fetchState);}"
+                "function applyEffect(){const e=document.getElementById('effect').value;fetch(`/api/effect?effect=${e}`,{method:'POST'}).then(fetchState);}"
+                "function saveProfile(){const n=document.getElementById('profile').value;fetch(`/api/profile/save?name=${encodeURIComponent(n)}`,{method:'POST'});} "
+                "function loadProfile(){const n=document.getElementById('profile').value;fetch(`/api/profile/load?name=${encodeURIComponent(n)}`,{method:'POST'}).then(fetchState);} "
+                "function saveAp(){const en=document.getElementById('apEnabled').checked;const ssid=document.getElementById('apSsid').value;const pass=document.getElementById('apPass').value;"
+                "fetch(`/api/ap?enabled=${en?1:0}&ssid=${encodeURIComponent(ssid)}&pass=${encodeURIComponent(pass)}`,{method:'POST'});}"
+                "function saveWifi(){const ssid=document.getElementById('wifiSsidInput').value;const pass=document.getElementById('wifiPassInput').value;"
+                "fetch(`/api/wifi?ssid=${encodeURIComponent(ssid)}&pass=${encodeURIComponent(pass)}`,{method:'POST'});}"
+                "function saveRoaming(){const rssi=document.getElementById('roamRssi').value;const interval=document.getElementById('roamInterval').value;"
+                "fetch(`/api/roaming?rssi=${encodeURIComponent(rssi)}&interval=${encodeURIComponent(interval)}`,{method:'POST'});}"
+                "function rebootDevice(){fetch('/api/device/reboot',{method:'POST'});}"
+                "function factoryReset(){fetch('/api/device/reset',{method:'POST'});}"
+                "function saveDeviceName(){const name=document.getElementById('deviceName').value;"
+                "fetch(`/api/device/name?name=${encodeURIComponent(name)}`,{method:'POST'});}"
+                "document.getElementById('deviceName').addEventListener('change',saveDeviceName);"
+                "setInterval(()=>{fetchState();fetchStatus();},3000);fetchState();fetchStatus();fetchAp();fetchRoaming();"
+                "</script></body></html>";
+  server.send(200, "text/html", html);
+}
+
+static void setupWebRoutes() {
+  server.on("/setup", HTTP_GET, handleSetupPage);
+  server.on("/setup", HTTP_POST, handleSetupPost);
+  server.on("/api/state", HTTP_GET, handleState);
+  server.on("/api/node", HTTP_POST, handleNodeUpdate);
+  server.on("/api/effect", HTTP_POST, handleEffectUpdate);
+  server.on("/api/profile/save", HTTP_POST, handleProfileSave);
+  server.on("/api/profile/load", HTTP_POST, handleProfileLoad);
+  server.on("/api/profiles", HTTP_GET, handleProfilesList);
+  server.on("/api/device/name", HTTP_POST, handleDeviceName);
+  server.on("/api/device/name", HTTP_GET, handleDeviceName);
+  server.on("/api/device/reboot", HTTP_POST, handleDeviceReboot);
+  server.on("/api/device/reset", HTTP_POST, handleFactoryReset);
+  server.on("/api/ap", HTTP_POST, handleApSettings);
+  server.on("/api/ap", HTTP_GET, handleApSettings);
+  server.on("/api/wifi", HTTP_POST, handleWiFiSettings);
+  server.on("/api/roaming", HTTP_POST, handleRoamingSettings);
+  server.on("/api/roaming", HTTP_GET, handleRoamingSettings);
+  server.on("/api/status", HTTP_GET, handleWiFiStatus);
+  server.on("/", HTTP_GET, handleControlPage);
+}
+
+static bool connectWiFi() {
+  String ssid = prefs.getString(PREF_WIFI_SSID, "");
+  String pass = prefs.getString(PREF_WIFI_PASS, "");
+  if (ssid.length() == 0) {
+    return false;
+  }
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(ssid.c_str(), pass.c_str());
+  unsigned long start = millis();
+  while (WiFi.status() != WL_CONNECTED && millis() - start < 12000) {
+    delay(300);
+  }
+  return WiFi.status() == WL_CONNECTED;
+}
+
+static void startAccessPoint() {
+  if (!deviceSettings.apEnabled) {
+    return;
+  }
+  WiFi.softAP(deviceSettings.apSsid.c_str(), deviceSettings.apPass.c_str());
+  Serial.print("AP aktiv: ");
+  Serial.println(deviceSettings.apSsid);
+}
+
+static void onFauxmoEvent(unsigned char deviceId, const char *deviceName, bool state, unsigned char value) {
+  (void)deviceName;
+
+  // deviceId entspricht dem Index in fauxmo.addDevice()
+  if (deviceId >= NODE_COUNT) {
+    return;
+  }
+
+  if (!state) {
+    nodes[deviceId].on = false;
+    applyNodeState(deviceId);
+    return;
+  }
+
+  // Alexa liefert value (0..255) als Helligkeit
+  uint8_t brightness = value;
+  // Beispiel: Rot mit variabler Helligkeit
+  nodes[deviceId].r = brightness;
+  nodes[deviceId].g = 0;
+  nodes[deviceId].b = 0;
+  nodes[deviceId].on = true;
+  applyNodeState(deviceId);
+}
+
+void setup() {
+  Serial.begin(115200);
+
+  Wire.begin(I2C_SDA, I2C_SCL, I2C_SPEED);
+
+  prefs.begin(PREFS_NAMESPACE, false);
+  randomSeed(esp_random());
+
+  for (size_t i = 0; i < NODE_COUNT; ++i) {
+    nodes[i] = {255, 0, 0, true};
+  }
+
+  deviceSettings.name = prefs.getString(PREF_DEVICE_NAME, "ESP32 RGB Controller");
+  deviceSettings.apEnabled = prefs.getBool(PREF_AP_ENABLED, true);
+  deviceSettings.apSsid = prefs.getString(PREF_AP_SSID, SETUP_SSID);
+  deviceSettings.apPass = prefs.getString(PREF_AP_PASS, SETUP_PASS);
+  deviceSettings.roamRssi = prefs.getInt(PREF_ROAM_RSSI, -80);
+  deviceSettings.roamInterval = prefs.getInt(PREF_ROAM_INTERVAL, 60);
+
+  if (!connectWiFi()) {
+    apMode = true;
+    WiFi.mode(WIFI_AP);
+    startAccessPoint();
+  } else {
+    Serial.print("Verbunden, IP: ");
+    Serial.println(WiFi.localIP());
+    if (deviceSettings.apEnabled) {
+      WiFi.mode(WIFI_AP_STA);
+      startAccessPoint();
+    }
+  }
+
+  setupWebRoutes();
+  server.begin();
+
+  fauxmo.createServer(true);
+  fauxmo.setPort(80);
+  fauxmo.enable(true);
+
+  for (size_t i = 0; i < NODE_COUNT; ++i) {
+    String deviceName = String("RGB Node ") + (i + 1);
+    fauxmo.addDevice(deviceName.c_str());
+  }
+
+  fauxmo.onSetState(onFauxmoEvent);
+
+  // Beispiel: Adressvergabe (nur ein unzugewiesener ATmega gleichzeitig einschalten!)
+  // assignAddress(0x09);
+  // assignAddress(0x0A);
+  // assignAddress(0x0B);
+}
+
+void loop() {
+  fauxmo.handle();
+  server.handleClient();
+  tickEffects();
+}

--- a/BankAssets/esp32_i2c_alexa/esp32_controller.ino
+++ b/BankAssets/esp32_i2c_alexa/esp32_controller.ino
@@ -288,13 +288,44 @@ static void handleApSettings() {
 }
 
 static void handleWiFiSettings() {
+  String ssid = prefs.getString(PREF_WIFI_SSID, "");
+  String pass = prefs.getString(PREF_WIFI_PASS, "");
+
   if (server.hasArg("ssid")) {
-    prefs.putString(PREF_WIFI_SSID, server.arg("ssid"));
+    String incoming = server.arg("ssid");
+    if (incoming.length() > 0) {
+      ssid = incoming;
+      prefs.putString(PREF_WIFI_SSID, ssid);
+    }
   }
   if (server.hasArg("pass")) {
-    prefs.putString(PREF_WIFI_PASS, server.arg("pass"));
+    String incoming = server.arg("pass");
+    if (incoming.length() > 0) {
+      pass = incoming;
+      prefs.putString(PREF_WIFI_PASS, pass);
+    }
   }
-  server.send(200, "text/plain", "saved");
+
+  bool connected = false;
+  if (ssid.length() > 0) {
+    WiFi.disconnect(true);
+    WiFi.mode(WIFI_STA);
+    WiFi.begin(ssid.c_str(), pass.c_str());
+    unsigned long start = millis();
+    while (WiFi.status() != WL_CONNECTED && millis() - start < 12000) {
+      delay(300);
+    }
+    connected = WiFi.status() == WL_CONNECTED;
+    if (connected && deviceSettings.apEnabled) {
+      WiFi.mode(WIFI_AP_STA);
+      startAccessPoint();
+    }
+  }
+
+  String response = "{\"saved\":true,\"connected\":";
+  response += String(connected ? "true" : "false");
+  response += ",\"ip\":\"" + WiFi.localIP().toString() + "\"}";
+  server.send(200, "application/json", response);
 }
 
 static void handleWiFiScan() {

--- a/BankAssets/esp32_i2c_alexa/pc_app/MainForm.vb
+++ b/BankAssets/esp32_i2c_alexa/pc_app/MainForm.vb
@@ -1,0 +1,179 @@
+Imports System
+Imports System.Net.Http
+Imports System.Text.Json
+Imports System.Threading.Tasks
+Imports System.Windows.Forms
+
+Public Class MainForm
+    Inherits Form
+
+    Private ReadOnly _client As HttpClient = New HttpClient()
+    Private ReadOnly _timer As Timer = New Timer()
+    Private ReadOnly _baseUrl As TextBox = New TextBox()
+    Private ReadOnly _nodeSelect As ComboBox = New ComboBox()
+    Private ReadOnly _colorButton As Button = New Button()
+    Private ReadOnly _offButton As Button = New Button()
+    Private ReadOnly _effectSelect As ComboBox = New ComboBox()
+    Private ReadOnly _profileName As TextBox = New TextBox()
+    Private ReadOnly _saveProfile As Button = New Button()
+    Private ReadOnly _loadProfile As Button = New Button()
+    Private ReadOnly _statusLabel As Label = New Label()
+
+    Private _nodeCount As Integer = 3
+
+    Public Sub New()
+        Text = "ESP32 RGB Controller"
+        Width = 520
+        Height = 360
+
+        Dim urlLabel As New Label() With {.Text = "ESP32 URL", .Left = 16, .Top = 20, .Width = 100}
+        _baseUrl.Left = 120
+        _baseUrl.Top = 16
+        _baseUrl.Width = 280
+        _baseUrl.Text = "http://esp32.local:8080"
+
+        Dim nodeLabel As New Label() With {.Text = "Node", .Left = 16, .Top = 60, .Width = 100}
+        _nodeSelect.Left = 120
+        _nodeSelect.Top = 56
+        _nodeSelect.Width = 120
+
+        _colorButton.Text = "Farbe setzen"
+        _colorButton.Left = 260
+        _colorButton.Top = 54
+        AddHandler _colorButton.Click, AddressOf OnSetColor
+
+        _offButton.Text = "Aus"
+        _offButton.Left = 380
+        _offButton.Top = 54
+        AddHandler _offButton.Click, AddressOf OnSetOff
+
+        Dim effectLabel As New Label() With {.Text = "Effekt", .Left = 16, .Top = 104, .Width = 100}
+        _effectSelect.Left = 120
+        _effectSelect.Top = 100
+        _effectSelect.Width = 140
+        _effectSelect.Items.AddRange(New Object() {"solid", "flicker", "rainbow", "pulse"})
+        _effectSelect.SelectedIndex = 0
+        AddHandler _effectSelect.SelectedIndexChanged, AddressOf OnEffectChanged
+
+        Dim profileLabel As New Label() With {.Text = "Profil", .Left = 16, .Top = 148, .Width = 100}
+        _profileName.Left = 120
+        _profileName.Top = 144
+        _profileName.Width = 140
+
+        _saveProfile.Text = "Speichern"
+        _saveProfile.Left = 280
+        _saveProfile.Top = 142
+        AddHandler _saveProfile.Click, AddressOf OnSaveProfile
+
+        _loadProfile.Text = "Laden"
+        _loadProfile.Left = 380
+        _loadProfile.Top = 142
+        AddHandler _loadProfile.Click, AddressOf OnLoadProfile
+
+        _statusLabel.Left = 16
+        _statusLabel.Top = 200
+        _statusLabel.Width = 460
+        _statusLabel.Text = "Status: -"
+
+        Controls.AddRange(New Control() {urlLabel, _baseUrl, nodeLabel, _nodeSelect, _colorButton, _offButton, effectLabel, _effectSelect, profileLabel, _profileName, _saveProfile, _loadProfile, _statusLabel})
+
+        _timer.Interval = 3000
+        AddHandler _timer.Tick, AddressOf OnPollTick
+        _timer.Start()
+
+        PopulateNodes()
+    End Sub
+
+    Private Sub PopulateNodes()
+        _nodeSelect.Items.Clear()
+        For i As Integer = 0 To _nodeCount - 1
+            _nodeSelect.Items.Add($"Node {i + 1}")
+        Next
+        If _nodeSelect.Items.Count > 0 Then
+            _nodeSelect.SelectedIndex = 0
+        End If
+    End Sub
+
+    Private Async Sub OnPollTick(sender As Object, e As EventArgs)
+        Await LoadStateAsync()
+    End Sub
+
+    Private Async Sub OnSetColor(sender As Object, e As EventArgs)
+        Using picker As New ColorDialog()
+            If picker.ShowDialog() = DialogResult.OK Then
+                Dim c = picker.Color
+                Await PostAsync($"/api/node?node={_nodeSelect.SelectedIndex}&r={c.R}&g={c.G}&b={c.B}&on=1")
+            End If
+        End Using
+    End Sub
+
+    Private Async Sub OnSetOff(sender As Object, e As EventArgs)
+        Await PostAsync($"/api/node?node={_nodeSelect.SelectedIndex}&on=0")
+    End Sub
+
+    Private Async Sub OnEffectChanged(sender As Object, e As EventArgs)
+        If _effectSelect.SelectedItem IsNot Nothing Then
+            Await PostAsync($"/api/effect?effect={_effectSelect.SelectedItem}")
+        End If
+    End Sub
+
+    Private Async Sub OnSaveProfile(sender As Object, e As EventArgs)
+        If String.IsNullOrWhiteSpace(_profileName.Text) Then
+            Return
+        End If
+        Await PostAsync($"/api/profile/save?name={Uri.EscapeDataString(_profileName.Text)}")
+    End Sub
+
+    Private Async Sub OnLoadProfile(sender As Object, e As EventArgs)
+        If String.IsNullOrWhiteSpace(_profileName.Text) Then
+            Return
+        End If
+        Await PostAsync($"/api/profile/load?name={Uri.EscapeDataString(_profileName.Text)}")
+    End Sub
+
+    Private Async Function LoadStateAsync() As Task
+        Try
+            Dim response = Await _client.GetAsync(BuildUrl("/api/state"))
+            response.EnsureSuccessStatusCode()
+            Dim payload = Await response.Content.ReadAsStringAsync()
+            Dim state = JsonSerializer.Deserialize(Of ApiState)(payload)
+            If state IsNot Nothing Then
+                _nodeCount = state.Nodes.Count
+                PopulateNodes()
+                If _effectSelect.Items.Contains(state.Effect) Then
+                    _effectSelect.SelectedItem = state.Effect
+                End If
+                _statusLabel.Text = $"Status: Effekt={state.Effect}, Nodes={state.Nodes.Count}"
+            End If
+        Catch ex As Exception
+            _statusLabel.Text = $"Status: Fehler ({ex.Message})"
+        End Try
+    End Function
+
+    Private Async Function PostAsync(path As String) As Task
+        Try
+            Dim response = Await _client.PostAsync(BuildUrl(path), New StringContent(String.Empty))
+            response.EnsureSuccessStatusCode()
+            Await LoadStateAsync()
+        Catch ex As Exception
+            _statusLabel.Text = $"Status: Fehler ({ex.Message})"
+        End Try
+    End Function
+
+    Private Function BuildUrl(path As String) As String
+        Dim baseUrl = _baseUrl.Text.Trim().TrimEnd("/"c)
+        Return baseUrl & path
+    End Function
+
+    Private Class ApiNode
+        Public Property R As Integer
+        Public Property G As Integer
+        Public Property B As Integer
+        Public Property On As Boolean
+    End Class
+
+    Private Class ApiState
+        Public Property Effect As String
+        Public Property Nodes As List(Of ApiNode)
+    End Class
+End Class

--- a/BankAssets/esp32_i2c_alexa/pc_app/MainForm.vb
+++ b/BankAssets/esp32_i2c_alexa/pc_app/MainForm.vb
@@ -1,6 +1,7 @@
 Imports System
 Imports System.Net.Http
 Imports System.Text.Json
+Imports System.Text.Json.Serialization
 Imports System.Threading.Tasks
 Imports System.Windows.Forms
 
@@ -169,7 +170,8 @@ Public Class MainForm
         Public Property R As Integer
         Public Property G As Integer
         Public Property B As Integer
-        Public Property On As Boolean
+        <JsonPropertyName("on")>
+        Public Property IsOn As Boolean
     End Class
 
     Private Class ApiState

--- a/BankAssets/esp32_i2c_alexa/pc_app/Program.vb
+++ b/BankAssets/esp32_i2c_alexa/pc_app/Program.vb
@@ -1,0 +1,10 @@
+Imports System
+Imports System.Windows.Forms
+
+Module Program
+    <STAThread>
+    Sub Main()
+        ApplicationConfiguration.Initialize()
+        Application.Run(New MainForm())
+    End Sub
+End Module

--- a/BankAssets/esp32_i2c_alexa/pc_app/Program.vb
+++ b/BankAssets/esp32_i2c_alexa/pc_app/Program.vb
@@ -4,7 +4,6 @@ Imports System.Windows.Forms
 Module Program
     <STAThread>
     Sub Main()
-        ApplicationConfiguration.Initialize()
         Application.Run(New MainForm())
     End Sub
 End Module

--- a/BankAssets/esp32_i2c_alexa/pc_app/RgbControllerApp.vbproj
+++ b/BankAssets/esp32_i2c_alexa/pc_app/RgbControllerApp.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/BankAssets/esp32_i2c_alexa/pc_app/RgbControllerApp.vbproj
+++ b/BankAssets/esp32_i2c_alexa/pc_app/RgbControllerApp.vbproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
### Motivation
- Provide a full example stack to control I2C RGB nodes from an ESP32 including persistent device and network settings and a web UI for mobile/desktop control. 
- Support simple ATmega RGB nodes that receive colors via I2C and persist address/color in EEPROM. 
- Offer desktop and mobile clients to access the ESP32 Web UI and REST API from Windows and Android devices. 

### Description
- Add a full ESP32 firmware example in `esp32_controller.ino` implementing I2C master control, device preferences (`Preferences`), web API endpoints (e.g. `/api/state`, `/api/node`, `/api/ap`), fauxmo Alexa emulation, effects, and an embedded web UI. 
- Add an ATmega node sketch `atmega_rgb_node.ino` implementing I2C slave handling, EEPROM address/color persistence, and commands `CMD_SET_RGB`, `CMD_SET_OFF`, and `CMD_ASSIGN_ADDRESS`. 
- Add a Windows example client under `pc_app/` (`MainForm.vb`, `Program.vb`, `RgbControllerApp.vbproj`) that talks to the ESP32 REST API. 
- Add a minimal Android WebView client under `android_app/` (Gradle scaffolding, `MainActivity.kt`, layout and resources) and document it in the `README.md` and `android_app/README.md`.

### Testing
- Generated a static preview screenshot of the new web UI via Playwright in an earlier step and the screenshot generation completed successfully. 
- No automated Arduino compilation or hardware flashing was performed for `esp32_controller.ino` or `atmega_rgb_node.ino`. 
- The Android project was added and documented but no Android Gradle build or device run was executed. 
- The Windows example (`pc_app/`) was added but no automated build/run was executed in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d56bb9c948331ae6e3267438d8199)